### PR TITLE
Use the same dotnet cli version and NuGet.config as arcade

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,8 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
+  <solution>
+    <add key="disableSourceControlIntegration" value="true" />
+  </solution>
+  <!-- Only specify feed for Arcade SDK (see https://github.com/Microsoft/msbuild/issues/2982) -->
   <packageSources>
     <clear />
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
+  <disabledPackageSources>
+    <clear />
+  </disabledPackageSources>
 </configuration>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "2.1.300"
+    "dotnet": "2.1.401"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.18619.2",


### PR DESCRIPTION
Attempt to fix what's described in https://github.com/NuGet/Home/issues/7654

/cc: @mmitche (as fyi)