### PR TITLE
Use open queues during PR, non-open during official build.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -100,9 +100,9 @@ jobs:
           --configuration $(_BuildConfig)
           --prepareMachine
         displayName: Unix Build / Publish
+- template: /eng/validation/templates/testing/helix.yml
 # Define all validation legs here in template form
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - template: /eng/validation/templates/testing/helix.yml
     - template: /eng/validation/templates/signing/sign.yml
     - job: Push_to_latest_channel
       displayName: Push Builds to 'Latest' channel

--- a/eng/validation/templates/testing/helix.yml
+++ b/eng/validation/templates/testing/helix.yml
@@ -11,9 +11,9 @@ jobs:
           steps:      
           - template: /eng/common/templates/steps/send-to-helix.yml
             parameters:
-              HelixSource: pr/dotnet/arcade-validation/$(Build.SourceBranch)
+              HelixSource: official/dotnet/arcade-validation/$(Build.SourceBranch)
               HelixType: test/product/
-              HelixTargetQueues: Windows.81.Amd64.Open;Ubuntu.1604.Amd64.Open
+              HelixTargetQueues: Windows.81.Amd64;Ubuntu.1604.Amd64
               XUnitProjects: $(Build.SourcesDirectory)/src/Validation/tests/Validation.Tests.csproj
               XUnitTargetFramework: netcoreapp2.0
               XUnitRunnerVersion: 2.4.1
@@ -22,6 +22,4 @@ jobs:
               DotNetCliVersion: 2.1.403
               EnableXUnitReporter: true
               WaitForWorkItemCompletion: true
-              IsExternal: true
-              Creator: arcade-validation
               HelixAccessToken: $(HelixApiAccessToken)

--- a/eng/validation/templates/testing/helix.yml
+++ b/eng/validation/templates/testing/helix.yml
@@ -13,7 +13,7 @@ jobs:
             parameters:
               HelixSource: official/dotnet/arcade-validation/$(Build.SourceBranch)
               HelixType: test/product/
-              HelixTargetQueues: Windows.81.Amd64;Ubuntu.1604.Amd64
+              HelixTargetQueues: Windows.10.Amd64;Ubuntu.1604.Amd64
               XUnitProjects: $(Build.SourcesDirectory)/src/Validation/tests/Validation.Tests.csproj
               XUnitTargetFramework: netcoreapp2.0
               XUnitRunnerVersion: 2.4.1

--- a/eng/validation/templates/testing/helix.yml
+++ b/eng/validation/templates/testing/helix.yml
@@ -6,14 +6,13 @@ jobs:
         - job: Validate_Helix
           displayName: Validate Helix
           variables:
+          - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
             - group: DotNet-HelixApi-Access
-            - _BuildConfig: Release
-          steps:      
+          - _BuildConfig: Release
+          steps:
           - template: /eng/common/templates/steps/send-to-helix.yml
             parameters:
-              HelixSource: official/dotnet/arcade-validation/$(Build.SourceBranch)
               HelixType: test/product/
-              HelixTargetQueues: Windows.10.Amd64;Ubuntu.1604.Amd64
               XUnitProjects: $(Build.SourcesDirectory)/src/Validation/tests/Validation.Tests.csproj
               XUnitTargetFramework: netcoreapp2.0
               XUnitRunnerVersion: 2.4.1
@@ -22,4 +21,12 @@ jobs:
               DotNetCliVersion: 2.1.403
               EnableXUnitReporter: true
               WaitForWorkItemCompletion: true
-              HelixAccessToken: $(HelixApiAccessToken)
+              ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+                HelixTargetQueues: Windows.10.Amd64.Open;Ubuntu.1604.Amd64.Open
+                HelixSource: pr/dotnet/arcade-validation/$(Build.SourceBranch)
+                IsExternal: true
+                creator: arcade-validation
+              ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+                HelixTargetQueues: Windows.10.Amd64;Ubuntu.1604.Amd64
+                HelixSource: official/dotnet/arcade-validation/$(Build.SourceBranch)
+                HelixAccessToken: $(HelixApiAccessToken)


### PR DESCRIPTION
We now do the send_to_helix job in both PR and official builds.

PR job uses anonymous mode, Official build uses authenticated mode.

fixes dotnet/arcade#1641