### PR TITLE
Add nuget version to Versions.props (TEST)

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,6 +5,7 @@
     <PreReleaseVersionLabel>prerelease</PreReleaseVersionLabel>
     <XUnitVersion>2.4.1-pre.build.4059</XUnitVersion>
     <XUnitVSRunnerVersion>2.4.1-pre.build.4059</XUnitVSRunnerVersion>
+    <NuGetVersion>4.4.0</NuGetVersion>
   </PropertyGroup>
   <PropertyGroup>
     <RestoreSources>


### PR DESCRIPTION
This seems to be the cause of nuget incorrectly restoring the wrong arcade SDK version.

Internal builds using this change haven't failed so far, but I want to test this using the external flow as well. 