### PR TITLE
add default for helix access token

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,6 +88,7 @@ jobs:
 
     - job: Validate_Helix
       variables:
+      - HelixApiAccessToken: ''
       - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
         - group: DotNet-HelixApi-Access
       - _BuildConfig: Release


### PR DESCRIPTION
Sending to Helix is broken without setting this parameter first.