### PR TITLE
Disable push to latest channel

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -151,6 +151,7 @@ jobs:
               /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
             displayName: Sign packages
 
+# Re-enable once we're ready to flow dependencies again after P2.
 #    - job: Push_to_latest_channel
 #      displayName: Push Builds to 'Latest' channel
 #      variables:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -151,20 +151,20 @@ jobs:
               /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
             displayName: Sign packages
 
-    - job: Push_to_latest_channel
-      displayName: Push Builds to 'Latest' channel
-      variables:
-        - group: Publish-Build-Assets
-      dependsOn:
-        - Windows_NT
-        - Linux
-        - Validate_Helix
-        - Validate_Signing
-        - Asset_Registry_Publish
-      steps:
-        - checkout: self
-          clean: true
-        - powershell: eng/validation/update-channel.ps1
-            -maestroEndpoint https://maestro-prod.westus2.cloudapp.azure.com
-            -barToken $(MaestroAccessToken)
-          displayName: Move build to 'Latest' channel 
+#    - job: Push_to_latest_channel
+#      displayName: Push Builds to 'Latest' channel
+#      variables:
+#        - group: Publish-Build-Assets
+#      dependsOn:
+#        - Windows_NT
+#        - Linux
+#        - Validate_Helix
+#        - Validate_Signing
+#        - Asset_Registry_Publish
+#      steps:
+#        - checkout: self
+#          clean: true
+#        - powershell: eng/validation/update-channel.ps1
+#            -maestroEndpoint https://maestro-prod.westus2.cloudapp.azure.com
+#            -barToken $(MaestroAccessToken)
+#          displayName: Move build to 'Latest' channel 


### PR DESCRIPTION
Temporary workaround. This should allow us to keep validating newer Arcade builds, but we won't push them to the channel where other repos would consume from.

@markwilkie @jcagme @mmitche 