### PR TITLE
Use serverRS4 queue instead of windows.10.amd64 for Helix validation

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -105,12 +105,12 @@ jobs:
           EnableXUnitReporter: true
           WaitForWorkItemCompletion: true
           ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-            HelixTargetQueues: Windows.10.Amd64.Open;Ubuntu.1604.Amd64.Open
+            HelixTargetQueues: Windows.10.Amd64.ServerRS4.Open;Ubuntu.1604.Amd64.Open
             HelixSource: pr/dotnet/arcade-validation/$(Build.SourceBranch)
             IsExternal: true
             Creator: arcade-validation
           ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-            HelixTargetQueues: Windows.10.Amd64;Ubuntu.1604.Amd64
+            HelixTargetQueues: Windows.10.Amd64.ServerRS4;Ubuntu.1604.Amd64
             HelixSource: official/dotnet/arcade-validation/$(Build.SourceBranch)
             HelixAccessToken: $(HelixApiAccessToken)
       displayName: Validate Helix


### PR DESCRIPTION
Get us out of the over-used windows.10.amd64/open queue.