### PR TITLE
Update list of package sources

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -7,6 +7,7 @@
   <packageSources>
     <clear />
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
+    <add key="arcade-validation" value="https://dotnetfeed.blob.core.windows.net/arcade-validation/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <disabledPackageSources>


### PR DESCRIPTION
Relates to: https://github.com/dotnet/arcade/issues/2085

Arcade soon will publish only to arcade-validation feed. This PR makes the eventual new packages available for arcade-validation builds.

Further details: Arcade-validation will add Arcade's build to another channel and that will cause the dotnet-core feed to be updated.