### PR TITLE
Fixes for arcade validation build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,7 +16,7 @@ jobs:
   parameters:
     enableMicrobuild: true
     enablePublishBuildArtifacts: true
-    enablePublishBuildAssets: true  # Publishing to BAR only depends on the build portion of the validation build
+    enablePublishBuildAssets: true
     enablePublishUsingPipelines: $(_PublishUsingPipelines)
     enableTelemetry: true
     helixRepo: dotnet/arcade-validation
@@ -127,15 +127,11 @@ jobs:
       displayName: Validate Helix
 
 # Jobs that should only run as part of internal builds.
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - template: /eng/common/templates/job/job.yml
-      parameters:
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      - job: Validate_Signing
         pool: 
-          name: NetCoreInternal-Int-Pool
+          name: NetCoreInternal-Pool
           queue: BuildPool.Windows.10.Amd64.VS2017
-        name: Validate_Signing
-        enableMicrobuild: true
-        enablePublishBuildArtifacts: true
         strategy:
           matrix:
             Test_Signing:
@@ -162,62 +158,62 @@ jobs:
               /p:TeamName=DotNetCore
               /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
             displayName: Sign packages
-    - job: Run_SDL
-      displayName: Run SDL tool
-      variables:
-        - group: SDL_Eng_KeyVault
-      steps:
-        - checkout: self
-          clean: true
-        - powershell: eng\common\build.ps1
-            -configuration Release
-            -restore
-            -prepareMachine
-            -ci
-            /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
-          displayName: Windows Build / Publish
-        - task: NuGetToolInstaller@1
-          displayName: 'Install NuGet.exe'
-        - task: NuGetCommand@2
-          displayName: 'Install Guardian'
-          inputs:
-            restoreSolution: $(Build.SourcesDirectory)\eng\common\sdl\packages.config
-            feedsToUse: config
-            nugetConfigPath: $(Build.SourcesDirectory)\eng\common\sdl\NuGet.config
-            externalFeedCredentials: GuardianConnect
-            restoreDirectory: $(Build.SourcesDirectory)\.packages
-        # Script to execute SDL tools.
-        # TsaNotificationEmail will be changed to dnceng@
-        # to check what the noise level would be with regular SDL runs.
-        - powershell: eng/common/sdl/execute-all-sdl-tools.ps1
-            -GuardianPackageName Microsoft.Guardian.Cli.0.3.2
-            -NugetPackageDirectory $(Build.SourcesDirectory)\.packages
-            -Repository $(Build.Repository.Name)
-            -SourceDirectory $(Build.SourcesDirectory)
-            -ArtifactsDirectory $(Build.SourcesDirectory)\artifacts
-            -DncEngAccessToken $(dn-bot-dotnet-build-rw-code-rw)
-            -SourceToolsList @("policheck","credscan","apiscan","fxcop")
-            -ArtifactToolsList @("binskim")
-            -TsaInstanceURL "https://devdiv.visualstudio.com/"
-            -TsaProjectName "DEVDIV"
-            -TsaNotificationEmail "subal@microsoft.com"
-            -TsaCodebaseAdmin "REDMOND\subal"
-            -TsaBugAreaPath "DevDiv\NET\NET Core "
-            -TsaIterationPath "DevDiv"
-            -TsaRepositoryName "Arcade"
-            -TsaCodebaseName "Arcade"
-            -TsaPublish $True
-          displayName: 'Execute SDL'
+      - job: Run_SDL
+        displayName: Run SDL tool
+        variables:
+          - group: SDL_Eng_KeyVault
+          - _BuildConfig: Release
+        steps:
+          - checkout: self
+            clean: true
+          - powershell: eng\common\build.ps1
+              -configuration $(_BuildConfig)
+              -restore
+              -prepareMachine
+              -ci
+              /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+            displayName: Windows Build / Publish
+          - task: NuGetToolInstaller@1
+            displayName: 'Install NuGet.exe'
+          - task: NuGetCommand@2
+            displayName: 'Install Guardian'
+            inputs:
+              restoreSolution: $(Build.SourcesDirectory)\eng\common\sdl\packages.config
+              feedsToUse: config
+              nugetConfigPath: $(Build.SourcesDirectory)\eng\common\sdl\NuGet.config
+              externalFeedCredentials: GuardianConnect
+              restoreDirectory: $(Build.SourcesDirectory)\.packages
+          # Script to execute SDL tools.
+          # TsaNotificationEmail will be changed to dnceng@
+          # to check what the noise level would be with regular SDL runs.
+          - powershell: eng/common/sdl/execute-all-sdl-tools.ps1
+              -GuardianPackageName Microsoft.Guardian.Cli.0.3.2
+              -NugetPackageDirectory $(Build.SourcesDirectory)\.packages
+              -Repository $(Build.Repository.Name)
+              -SourceDirectory $(Build.SourcesDirectory)
+              -ArtifactsDirectory $(Build.SourcesDirectory)\artifacts
+              -DncEngAccessToken $(dn-bot-dotnet-build-rw-code-rw)
+              -SourceToolsList @("policheck","credscan","apiscan","fxcop")
+              -ArtifactToolsList @("binskim")
+              -TsaInstanceURL "https://devdiv.visualstudio.com/"
+              -TsaProjectName "DEVDIV"
+              -TsaNotificationEmail "subal@microsoft.com"
+              -TsaCodebaseAdmin "REDMOND\subal"
+              -TsaBugAreaPath "DevDiv\NET\NET Core "
+              -TsaIterationPath "DevDiv"
+              -TsaRepositoryName "Arcade"
+              -TsaCodebaseName "Arcade"
+              -TsaPublish $True
+            displayName: 'Execute SDL'
 
-    - job: Push_to_latest_channel
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+  - template: /eng/common/templates/job/job.yml
+    parameters:
+      name: Push_to_latest_channel
       displayName: Push Builds to 'Latest' channel
       variables:
         - group: Publish-Build-Assets
       dependsOn:
-        - Windows_NT
-        - Linux
-        - Validate_Helix
-        - Validate_Signing
         - Asset_Registry_Publish
       steps:
         - checkout: self


### PR DESCRIPTION
Fixes https://github.com/dotnet/arcade/issues/2971

* Stop using the int pool provider
* The Validate_Signing and SDL jobs are now part of the jobs collection from the jobs.yml templates, so that they are required to succeed before the publish to BAR job.
* The push to 'latest' channel job now only depends only on the publish to BAR job.