### PR TITLE
Remove BinSkim from Arcade-Validation build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -169,13 +169,6 @@ jobs:
       steps:
         - checkout: self
           clean: true
-        - powershell: eng\common\build.ps1
-            -configuration Release
-            -restore
-            -prepareMachine
-            -ci
-            /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
-          displayName: Windows Build / Publish
         - task: NuGetToolInstaller@1
           displayName: 'Install NuGet.exe'
         - task: NuGetCommand@2
@@ -197,7 +190,6 @@ jobs:
             -ArtifactsDirectory $(Build.SourcesDirectory)\artifacts
             -DncEngAccessToken $(dn-bot-dotnet-build-rw-code-rw)
             -SourceToolsList @("policheck","credscan","apiscan","fxcop")
-            -ArtifactToolsList @("binskim")
             -TsaInstanceURL "https://devdiv.visualstudio.com/"
             -TsaProjectName "DEVDIV"
             -TsaNotificationEmail "subal@microsoft.com"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -187,7 +187,7 @@ jobs:
             -NugetPackageDirectory $(Build.SourcesDirectory)\.packages
             -Repository $(Build.Repository.Name)
             -SourceDirectory $(Build.SourcesDirectory)
-            -ArtifactsDirectory $(Build.SourcesDirectory)\artifacts
+            -ArtifactsDirectory $(Build.SourcesDirectory)
             -DncEngAccessToken $(dn-bot-dotnet-build-rw-code-rw)
             -SourceToolsList @("policheck","credscan","apiscan","fxcop")
             -TsaInstanceURL "https://devdiv.visualstudio.com/"


### PR DESCRIPTION
Removing BinSkim from arcade-validation build as it takes more than an hr to finish and is not practical to run for every build. 
https://github.com/dotnet/core-eng/issues/6550