### PR TITLE
Remove BinSkim from arcade-validation builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -166,13 +166,6 @@ jobs:
         steps:
           - checkout: self
             clean: true
-          - powershell: eng\common\build.ps1
-              -configuration $(_BuildConfig)
-              -restore
-              -prepareMachine
-              -ci
-              /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
-            displayName: Windows Build / Publish
           - task: NuGetToolInstaller@1
             displayName: 'Install NuGet.exe'
           - task: NuGetCommand@2
@@ -191,10 +184,9 @@ jobs:
               -NugetPackageDirectory $(Build.SourcesDirectory)\.packages
               -Repository $(Build.Repository.Name)
               -SourceDirectory $(Build.SourcesDirectory)
-              -ArtifactsDirectory $(Build.SourcesDirectory)\artifacts
+              -ArtifactsDirectory $(Build.SourcesDirectory)
               -DncEngAccessToken $(dn-bot-dotnet-build-rw-code-rw)
               -SourceToolsList @("policheck","credscan","apiscan","fxcop")
-              -ArtifactToolsList @("binskim")
               -TsaInstanceURL "https://devdiv.visualstudio.com/"
               -TsaProjectName "DEVDIV"
               -TsaNotificationEmail "subal@microsoft.com"


### PR DESCRIPTION
Remove BinSkim from arcade-validation builds as it takes an hour to finish and does not make sense to be run with every build. 
https://github.com/dotnet/core-eng/issues/6550