### PR TITLE
Use windows.10.amd64 for windows helix validation

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -116,12 +116,12 @@ jobs:
           EnableXUnitReporter: true
           WaitForWorkItemCompletion: true
           ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-            HelixTargetQueues: Windows.10.Amd64.ServerRS4.Open;Debian.9.Amd64.Open
+            HelixTargetQueues: Windows.10.Amd64.Open;Debian.9.Amd64.Open
             HelixSource: pr/dotnet/arcade-validation/$(Build.SourceBranch)
             IsExternal: true
             Creator: arcade-validation
           ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-            HelixTargetQueues: Windows.10.Amd64.ServerRS4;Debian.9.Amd64
+            HelixTargetQueues: Windows.10.Amd64;Debian.9.Amd64
             HelixSource: official/dotnet/arcade-validation/$(Build.SourceBranch)
             HelixAccessToken: $(HelixApiAccessToken)
       displayName: Validate Helix


### PR DESCRIPTION
There's no reason to use the serverRS4 queue, and it gets backed up with people who actually need server features.