### PR TITLE
only do the push build to latest channel job if running from master b…

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -172,6 +172,7 @@ jobs:
               -prepareMachine
               -ci
               /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+            displayName: Windows Build / Publish
           - task: NuGetToolInstaller@1
             displayName: 'Install NuGet.exe'
           - task: NuGetCommand@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -166,6 +166,12 @@ jobs:
         steps:
           - checkout: self
             clean: true
+          - powershell: eng\common\build.ps1
+              -configuration $(_BuildConfig)
+              -restore
+              -prepareMachine
+              -ci
+              /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
           - task: NuGetToolInstaller@1
             displayName: 'Install NuGet.exe'
           - task: NuGetCommand@2
@@ -198,7 +204,7 @@ jobs:
               -TsaPublish $True
             displayName: 'Execute SDL'
 
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranchName'], 'master')) }}:
   - template: /eng/common/templates/job/job.yml
     parameters:
       name: Push_to_latest_channel


### PR DESCRIPTION
…ranch

fixes https://github.com/dotnet/arcade/issues/2993

* Also adds back the build step in the SDL job