### PR TITLE
remove fxcop since it's full of errors and timing out

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -193,7 +193,7 @@ jobs:
               -SourceDirectory $(Build.SourcesDirectory)
               -ArtifactsDirectory $(Build.SourcesDirectory)
               -DncEngAccessToken $(dn-bot-dotnet-build-rw-code-rw)
-              -SourceToolsList @("policheck","credscan","apiscan","fxcop")
+              -SourceToolsList @("policheck","credscan","apiscan")
               -TsaInstanceURL "https://devdiv.visualstudio.com/"
               -TsaProjectName "DEVDIV"
               -TsaNotificationEmail "subal@microsoft.com"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -193,7 +193,7 @@ jobs:
               -SourceDirectory $(Build.SourcesDirectory)
               -ArtifactsDirectory $(Build.SourcesDirectory)
               -DncEngAccessToken $(dn-bot-dotnet-build-rw-code-rw)
-              -SourceToolsList @("policheck","credscan","apiscan")
+              -SourceToolsList @("policheck","credscan")
               -TsaInstanceURL "https://devdiv.visualstudio.com/"
               -TsaProjectName "DEVDIV"
               -TsaNotificationEmail "subal@microsoft.com"


### PR DESCRIPTION
Remove fxcop from the sourceToolsList since it's been causing arcade-validation builds to time out, and is blocking the flow of new versions of the arcade sdk.

https://dev.azure.com/dnceng/internal/_build/results?buildId=215785
The fxcop run is full of errors like:

```
    FxCop completed with exit code 9
    Error running FxCop job: 1 of 3828
    FxCop completed with an Error exit code: 9. An analysis error (possibly assembly load error) occurred.
```
and 

```
FxCop completed with exit code 1
    Error running FxCop job: 3 of 3828
    FxCop completed with an Error exit code: 1. A fatal error occurred. Some of the possible conditions that are considered fatal errors: 1) The analysis could not be performed because of insufficient input. 2) The analysis threw an exception that is not handled by FxCopCmd. 3) The specified project file could not be found or is corrupted. 4) The output option was not specified or the file could not be written.
```

CC @sunandabalu 