### PR TITLE
Copy sources from Versions.props to NuGet.config

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -9,8 +9,8 @@
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="arcade-validation" value="https://dotnetfeed.blob.core.windows.net/arcade-validation/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="arcade-validation" value="https://dotnet.myget.org/F/symreader-converter/api/v3/index.json" />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="symreader-converter" value="https://dotnet.myget.org/F/symreader-converter/api/v3/index.json" />
+    <add key="symreader" value="https://dotnet.myget.org/F/symreader/api/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />

--- a/NuGet.config
+++ b/NuGet.config
@@ -9,6 +9,8 @@
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="arcade-validation" value="https://dotnetfeed.blob.core.windows.net/arcade-validation/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="arcade-validation" value="https://dotnet.myget.org/F/symreader-converter/api/v3/index.json" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />


### PR DESCRIPTION
**TL;DR**

We need that all restore sources are located in `NuGet.config` since internal feeds can only be restored from there. More details including next steps [here](https://github.com/dotnet/arcade/blob/master/Documentation/RestoreSourcesUpdateStatus.md)