### PR TITLE
Add new variable since we publish to validation channel

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,6 +5,8 @@ variables:
     value: true
   - name: _DotNetArtifactsCategory
     value: .NETCore
+  - name: _DotNetValidationArtifactsCategory
+    value: .NETCoreValidation
 
 resources:
   containers:


### PR DESCRIPTION
New variable was introduced in https://github.com/dotnet/arcade/pull/3402 and since Arcade-validation publishes to the validation channel, it needs to set it.