### PR TITLE
Versions.props cleanup

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -7,13 +7,4 @@
     <XUnitVSRunnerVersion>2.4.1-pre.build.4059</XUnitVSRunnerVersion>
     <NuGetVersion>4.4.0</NuGetVersion>
   </PropertyGroup>
-  <PropertyGroup>
-    <RestoreSources>
-      $(RestoreSources);
-      https://dotnetfeed.blob.core.windows.net/arcade-validation/index.json;
-      https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
-      https://dotnet.myget.org/F/symreader-converter/api/v3/index.json;
-      https://dotnet.myget.org/F/symreader/api/v3/index.json
-    </RestoreSources>
-  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Remove `RestoreSources` from Versions.props in order to complete [step 2](https://github.com/dotnet/arcade/blob/master/Documentation/RestoreSourcesUpdateStatus.md#part-2)