### PR TITLE
Fix release/3.x builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -199,6 +199,7 @@ stages:
       enableSourceLinkValidation: false
       # This is to enable SDL runs part of Post-Build Validation Stage
       SDLValidationParameters:
+        continueOnError: false
         enable: true
         params: ' -SourceToolsList @("policheck","credscan")
         -TsaInstanceURL "https://devdiv.visualstudio.com/"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -199,8 +199,8 @@ stages:
       enableSourceLinkValidation: false
       # This is to enable SDL runs part of Post-Build Validation Stage
       SDLValidationParameters:
-        continueOnError: false
         enable: true
+        continueOnError: false
         params: ' -SourceToolsList @("policheck","credscan")
         -TsaInstanceURL "https://devdiv.visualstudio.com/"
         -TsaProjectName "DEVDIV"


### PR DESCRIPTION
Somehow the post-build SDL parameters default values aren't working. If we don't pass the `continueOnError` parameter explicitly here the default value will be "" and triggering the build will fail. 

I don't know why this is only happening in this branch and why it was working before in the master branch. If I move the [parameter out of](https://github.com/dotnet/arcade-validation/blob/master/eng/common/templates/post-build/post-build.yml#L7) the `SDKValidationParameters` group everything works fine.

@sunandabalu can you take a look at a general solution for this? :-) This PR is just to unblock arcade-validation.