### PR TITLE
move Push Build to '.NET Tools 3' channel to its own stage

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -171,23 +171,6 @@ stages:
                 /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
               displayName: Sign packages
 
-  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranchName'], 'master')) }}:
-    - template: /eng/common/templates/job/job.yml
-      parameters:
-        name: Push_to_3x_channel
-        displayName: Push Builds to '.NET Tools 3' channel
-        variables:
-          - group: Publish-Build-Assets
-        dependsOn:
-          - Asset_Registry_Publish
-        steps:
-          - checkout: self
-            clean: true
-          - powershell: eng/validation/update-channel.ps1
-              -maestroEndpoint https://maestro-prod.westus2.cloudapp.azure.com
-              -barToken $(MaestroAccessToken)
-            displayName: Move build to '.NET Tools 3' channel
-
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - template: eng\common\templates\post-build\post-build.yml
     parameters:
@@ -210,3 +193,31 @@ stages:
         -TsaRepositoryName "Arcade-Validation"
         -TsaCodebaseName "Arcade-Validation"
         -TsaPublish $True'
+
+  - stage: Push_to_latest_channel
+    displayName: Push Build to '.NET Tools 3' channel
+    dependsOn:
+      # This will run only after all the publishing stages have run.
+      # These stages are introduced in the eng/common/templates/post-build/channels YAML templates
+      - NetCore_Dev31_Publish
+      - NetCore_Dev30_Publish
+      - NetCore_Dev5_Publish
+      - NetCore_Release30_Publish
+      - NetCore_Release31_Publish
+      - NetCore_Tools_Latest_Publish
+      - PVR_Publish
+      - NetCore_3_Tools_Validation_Publish
+      - NetCore_3_Tools_Publish
+      - NetCore_30_Internal_Servicing_Publishing
+    jobs:
+    - template: /eng/common/templates/job/job.yml
+      parameters:
+        name: Push_to_3x_channel
+        displayName: Push Builds to '.NET Tools 3' channel
+        steps:
+          - checkout: self
+            clean: true
+          - powershell: eng/validation/update-channel.ps1
+              -maestroEndpoint https://maestro-prod.westus2.cloudapp.azure.com
+              -barToken $(MaestroAccessToken)
+            displayName: Move build to '.NET Tools 3' channel

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -195,7 +195,7 @@ stages:
         -TsaPublish $True'
 
   - stage: Push_to_latest_channel
-    displayName: Push Build to '.NET Tools 3' channel
+    displayName: Push Build to '.NET 3 Tools' channel
     variables:
       - group: Publish-Build-Assets
     dependsOn:
@@ -215,11 +215,11 @@ stages:
     - template: /eng/common/templates/job/job.yml
       parameters:
         name: Push_to_3x_channel
-        displayName: Push Builds to '.NET Tools 3' channel
+        displayName: Push Builds to '.NET 3 Tools' channel
         steps:
           - checkout: self
             clean: true
           - powershell: eng/validation/update-channel.ps1
               -maestroEndpoint https://maestro-prod.westus2.cloudapp.azure.com
               -barToken $(MaestroAccessToken)
-            displayName: Move build to '.NET Tools 3' channel
+            displayName: Move build to '.NET 3 Tools' channel

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -196,6 +196,8 @@ stages:
 
   - stage: Push_to_latest_channel
     displayName: Push Build to '.NET Tools 3' channel
+    variables:
+      - group: Publish-Build-Assets
     dependsOn:
       # This will run only after all the publishing stages have run.
       # These stages are introduced in the eng/common/templates/post-build/channels YAML templates

--- a/eng/validation/update-channel.ps1
+++ b/eng/validation/update-channel.ps1
@@ -2,7 +2,7 @@ Param(
   [string] $maestroEndpoint,
   [string] $barToken,
   [string] $apiVersion = "2018-07-16",
-  [string] $targetChannelName = ".NET Tools 3"
+  [string] $targetChannelName = ".NET 3 Tools"
 )
 
 . $PSScriptRoot\..\common\tools.ps1


### PR DESCRIPTION
Release/3.x version of https://github.com/dotnet/arcade-validation/pull/866
fixes https://github.com/dotnet/arcade/issues/3982

Test build: https://dev.azure.com/dnceng/internal/_build/results?buildId=361873&view=results