### PR TITLE
Remove blob feed from nuget.config

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -8,7 +8,6 @@
     <clear />
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
-    <add key="arcade-validation" value="https://dotnetfeed.blob.core.windows.net/arcade-validation/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="symreader-converter" value="https://dotnet.myget.org/F/symreader-converter/api/v3/index.json" />
     <add key="symreader" value="https://dotnet.myget.org/F/symreader/api/v3/index.json" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -6,7 +6,6 @@
   <!-- Only specify feed for Arcade SDK (see https://github.com/Microsoft/msbuild/issues/2982) -->
   <packageSources>
     <clear />
-    <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="symreader-converter" value="https://dotnet.myget.org/F/symreader-converter/api/v3/index.json" />


### PR DESCRIPTION
This caused a problem when recently arcade stopped publishing to dotnet-tools because of an issue with the order a change should have been made. https://github.com/dotnet/arcade/pull/4117

Because arcade-validation was in this nuget.config, this problem was not caught immediately, and only seen when arcade was ingested into itself.