### PR TITLE
use dotnet-eng feed to react to feed change

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -6,7 +6,7 @@
   <!-- Only specify feed for Arcade SDK (see https://github.com/Microsoft/msbuild/issues/2982) -->
   <packageSources>
     <clear />
-    <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
+    <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="symreader-converter" value="https://dotnet.myget.org/F/symreader-converter/api/v3/index.json" />
     <add key="symreader" value="https://dotnet.myget.org/F/symreader/api/v3/index.json" />


### PR DESCRIPTION
I'll merge this once Arcade-validation is broken by the dependency update from https://github.com/dotnet/arcade/pull/4279

That will let us make sure the channel and feed configurations are still correct with the initial change.