### PR TITLE
Add Scheduled job using Staging Pool Provider

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,6 +15,12 @@ variables:
   - ${{ if and(ne(variables.PoolProvider, ''), ne(variables['System.TeamProject'], 'public')) }}:
     - name: PoolProvider
       value: NetCoreInternal-Pool
+  - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule')) }}:
+    - name: PoolProvider
+      value: NetCorePublicInt-Pool
+  - ${{ if and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule')) }}:
+    - name: PoolProvider
+      value: NetCoreInternalInt-Pool
 
 trigger:
   batch: true
@@ -22,6 +28,14 @@ trigger:
     include:
       - master
       - release/3.x
+
+schedules:
+- cron: "0 0 * * *"
+  displayName: Once a day build using Staging pools (at midnight)
+  branches:
+    include:
+    - master
+  always: true
 
 resources:
   containers:


### PR DESCRIPTION
We'd like to make sure that our staging machines are healthy, so this change adds a scheduled build that uses the staging pool provider instead of prod.