### PR TITLE
add missing channel publishing dependency to push builds stage

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -203,15 +203,20 @@ stages:
     dependsOn:
       # This will run only after all the publishing stages have run.
       # These stages are introduced in the eng/common/templates/post-build/channels YAML templates
-      - NetCore_Dev31_Publish
       - NetCore_Dev5_Publish
-      - NetCore_Release30_Publish
-      - NetCore_Release31_Publish
+      - NetCore_Dev31_Publish
       - NetCore_Tools_Latest_Publish
       - PVR_Publish
       - NetCore_3_Tools_Validation_Publish
       - NetCore_3_Tools_Publish
+      - NetCore_Release30_Publish
+      - NetCore_Release31_Publish
+      - NetCore_Blazor31_Features_Publish
       - NetCore_30_Internal_Servicing_Publishing
+      - NetCore_31_Internal_Servicing_Publishing
+      - General_Testing_Publish
+      - NETCore_Tooling_Dev_Publishing
+      - NETCore_Tooling_Release_Publishing
     jobs:
     - template: /eng/common/templates/job/job.yml
       parameters:


### PR DESCRIPTION
Add some of the channels that we've introduced recently, and reorder the list so that it matches the order in post-build.yml