### PR TITLE
Use dn-bot account to trigger promotion pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -241,6 +241,6 @@ stages:
           - powershell: eng/validation/update-channel.ps1
               -maestroEndpoint https://maestro-prod.westus2.cloudapp.azure.com
               -barToken $(MaestroAccessToken)
-              -azdoToken $(AzdoDncEngQueueBuildsToken)
+              -azdoToken $(dn-bot-dnceng-build-rw-code-rw)
               -githubToken $(BotAccount-dotnet-bot-repo-PAT)
             displayName: Move build to 'Latest' channel 


### PR DESCRIPTION
The PAT currently in use is a developer PAT. Changing to a dn-bot owned PAT.

Tested this locally and the new PAT is able to queue the promotion builds.