### PR TITLE
Arcade Validation should only look at product repo latest builds instead of LKGs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,56 +43,216 @@ resources:
     image: microsoft/dotnet-buildtools-prereqs:ubuntu-14.04-cross-0cd4667-20170319080304
 
 stages:
-# Arcade validation with additional repos
-- stage: Validate_Arcade_With_Consumer_Repositories
-  displayName: Validate Arcade with Consumer Repositories
+- stage: build
+  displayName: Build
   jobs:
-    - template: /eng/common/templates/job/job.yml
-      parameters:
-        name: Validate_Arcade_With_Consumer_Repositories
-        displayName: Validate Arcade with Consumer Repositories
-        timeoutInMinutes: 240
+  - template: /eng/common/templates/jobs/jobs.yml
+    parameters:
+      enableMicrobuild: true
+      enablePublishBuildArtifacts: true
+      enablePublishBuildAssets: true
+      enablePublishUsingPipelines: ${{ variables._PublishUsingPipelines }}
+      enableTelemetry: true
+      helixRepo: dotnet/arcade-validation
+      jobs:
+      - job: Windows_NT
+        pool:
+          name: $(PoolProvider) # This is a queue-time parameter; Public default is NetCorePublic-Pool; Internal default is NetCoreInternal-Pool
+          ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+            queue: BuildPool.Server.Amd64.VS2017.Arcade.Open
+          ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+            queue: BuildPool.Server.Amd64.VS2017.Arcade
         variables:
-          - group: Publish-Build-Assets
-          - group: DotNetBot-GitHub
-          - group: DotNet-Blob-Feed
-          - group: DotNet-Symbol-Server-Pats
-          - group: DotNet-VSTS-Infra-Access
+        - _InternalBuildArgs: ''
+
+        # Only enable publishing in non-public, non PR scenarios.
+        - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+          - _InternalBuildArgs: /p:DotNetSignType=$(_SignType) 
+              /p:TeamName=$(_TeamName)
+              /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
+              /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+
         strategy:
           matrix:
-            ValidateWithRuntime:
-              _azdoOrg: "dnceng"
-              _azdoProject: "internal"
-              _buildDefinitionId: 679
-              _githubRepoName: "runtime"
-              _azdoToken: $(dn-bot-dnceng-build-rw-code-rw)
-              _optionalParameters: "-azdoRepoName 'dotnet-runtime' -subscribedBranchName 'master'"
-            ValidateWithASPNETCore:
-              _azdoOrg: "dnceng"
-              _azdoProject: "internal"
-              _buildDefinitionId: 21
-              _githubRepoName: "aspnetcore"
-              _azdoToken: $(dn-bot-dnceng-build-rw-code-rw)
-              _optionalParameters: "-azdoRepoName 'dotnet-aspnetcore' -subscribedBranchName 'master'"
-            ValidateWithInstaller:
-              _azdoOrg: "dnceng"
-              _azdoProject: "internal"
-              _buildDefinitionId: 286
-              _githubRepoName: "installer"
-              _azdoToken: $(dn-bot-dnceng-build-rw-code-rw)
-              _optionalParameters: "-azdoRepoName 'dotnet-installer' -subscribedBranchName 'master'"
+            Build_Release:
+              _BuildConfig: Release
+              # PRs or external builds are not signed.
+              ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+                _SignType: test
+              ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+                _SignType: real
+            ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+              Build_Debug:
+                _BuildConfig: Debug
+                _SignType: test
         steps:
-          - checkout: self
-            clean: true
-          - powershell: eng\validation\build-arcadewithrepo.ps1
-              -azdoOrg $(_azdoOrg)
-              -azdoProject $(_azdoProject)
-              -buildDefinitionId $(_buildDefinitionId)
-              -azdoToken $(_azdoToken)
-              -githubUser "dotnet-bot"
-              -githubPAT $(BotAccount-dotnet-bot-repo-PAT)
-              -githubOrg "dotnet"
-              -githubRepoName $(_githubRepoName)
-              -barToken $(MaestroAccessToken)
-              $(_optionalParameters)
-            name: buildarcade
+        - checkout: self
+          clean: true
+        # Use utility script to run script command dependent on agent OS.
+        - script: eng\common\cibuild.cmd
+            -configuration $(_BuildConfig) 
+            -prepareMachine
+            $(_InternalBuildArgs)
+          displayName: Windows Build / Publish
+
+      - job: Linux
+        container: LinuxContainer
+        pool:
+          ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+            name: $(PoolProvider) # This is a queue-time parameter; Public default is NetCorePublic-Pool; Internal default is NetCoreInternal-Pool
+            queue: BuildPool.Ubuntu.1604.Amd64.Arcade.Open
+          ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+            name: Hosted Ubuntu 1604
+        strategy:
+          matrix:
+            Build_Debug:
+              _BuildConfig: Debug
+              _SignType: none
+            Build_Release:
+              _BuildConfig: Release
+              _SignType: none
+        steps:
+        - checkout: self
+          clean: true
+        - script: eng/common/cibuild.sh
+            --configuration $(_BuildConfig)
+            --prepareMachine
+          displayName: Unix Build / Publish
+
+      - job: Validate_Helix
+        variables:
+        - HelixApiAccessToken: ''
+        - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+          - group: DotNet-HelixApi-Access
+        - _BuildConfig: Release
+        steps:
+        - template: /eng/common/templates/steps/send-to-helix.yml
+          parameters:
+            HelixType: test/product/
+            XUnitProjects: $(Build.SourcesDirectory)/src/Validation/tests/Validation.Tests.csproj
+            XUnitTargetFramework: netcoreapp2.0
+            XUnitRunnerVersion: 2.4.1
+            IncludeDotNetCli: true
+            DotNetCliPackageType: sdk
+            DotNetCliVersion: 2.1.403
+            EnableXUnitReporter: true
+            WaitForWorkItemCompletion: true
+            ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+              HelixTargetQueues: Windows.10.Amd64.Arcade.Open;Debian.9.Amd64.Arcade.Open
+              HelixSource: pr/dotnet/arcade-validation/$(Build.SourceBranch)
+              IsExternal: true
+              Creator: arcade-validation
+            ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+              HelixTargetQueues: Windows.10.Amd64.Arcade;Debian.9.Amd64.Arcade
+              HelixSource: official/dotnet/arcade-validation/$(Build.SourceBranch)
+              HelixAccessToken: $(HelixApiAccessToken)
+        displayName: Validate Helix
+
+  # Jobs that should only run as part of internal builds.
+      - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+        - job: Validate_Signing
+          pool: 
+            name: $(PoolProvider) # This is a queue-time parameter; Public default is NetCorePublic-Pool; Internal default is NetCoreInternal-Pool
+            queue: BuildPool.Server.Amd64.VS2017.Arcade
+          strategy:
+            matrix:
+              Test_Signing:
+                _BuildConfig: Debug
+                _SignType: test
+              Real_Signing:
+                _BuildConfig: Release
+                _SignType: real
+          steps:
+            - checkout: self
+              clean: true
+            - task: CopyFiles@2
+              displayName: Copy test packages to artifacts directory
+              inputs:
+                sourceFolder: $(Build.SourcesDirectory)\src\validation\resources
+                targetFolder: $(Build.SourcesDirectory)\artifacts\packages\$(_BuildConfig)\NonShipping
+            - powershell: eng\common\build.ps1
+                -configuration $(_BuildConfig)
+                -restore
+                -prepareMachine
+                -sign
+                -ci
+                /p:DotNetSignType=$(_SignType)
+                /p:TeamName=DotNetCore
+                /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+              displayName: Sign packages
+
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+  - template: eng\common\templates\post-build\post-build.yml
+    parameters:
+      # Symbol validation isn't being very reliable lately. This should be enabled back
+      # once this issue is resolved: https://github.com/dotnet/arcade/issues/2871
+      enableSymbolValidation: false
+      # Sourcelink validation isn't passing for Arcade-validation. This should be
+      # enabled back once this issue is resolved: https://github.com/dotnet/arcade/issues/3069
+      enableSourceLinkValidation: false
+      # This is to enable SDL runs part of Post-Build Validation Stage
+      SDLValidationParameters:
+        enable: true
+        params: ' -SourceToolsList @("policheck","credscan")
+        -TsaInstanceURL $(_TsaInstanceURL)
+        -TsaProjectName $(_TsaProjectName)
+        -TsaNotificationEmail $(_TsaNotificationEmail)
+        -TsaCodebaseAdmin $(_TsaCodebaseAdmin)
+        -TsaBugAreaPath $(_TsaBugAreaPath)
+        -TsaIterationPath $(_TsaIterationPath)
+        -TsaRepositoryName "Arcade-Validation"
+        -TsaCodebaseName "Arcade-Validation"
+        -TsaPublish $True'
+  # Arcade validation with additional repos
+  - stage: Validate_Arcade_With_Consumer_Repositories
+    displayName: Validate Arcade with Consumer Repositories
+    jobs:
+      - template: /eng/common/templates/job/job.yml
+        parameters:
+          name: Validate_Arcade_With_Consumer_Repositories
+          displayName: Validate Arcade with Consumer Repositories
+          timeoutInMinutes: 240
+          variables:
+            - group: Publish-Build-Assets
+            - group: DotNetBot-GitHub
+            - group: DotNet-Blob-Feed
+            - group: DotNet-Symbol-Server-Pats
+            - group: DotNet-VSTS-Infra-Access
+          strategy:
+            matrix:
+              ValidateWithRuntime:
+                _azdoOrg: "dnceng"
+                _azdoProject: "internal"
+                _buildDefinitionId: 679
+                _githubRepoName: "runtime"
+                _azdoToken: $(dn-bot-dnceng-build-rw-code-rw)
+                _optionalParameters: "-azdoRepoName 'dotnet-runtime' -subscribedBranchName 'master'"
+              ValidateWithASPNETCore:
+                _azdoOrg: "dnceng"
+                _azdoProject: "internal"
+                _buildDefinitionId: 21
+                _githubRepoName: "aspnetcore"
+                _azdoToken: $(dn-bot-dnceng-build-rw-code-rw)
+                _optionalParameters: "-azdoRepoName 'dotnet-aspnetcore' -subscribedBranchName 'master'"
+              ValidateWithInstaller:
+                _azdoOrg: "dnceng"
+                _azdoProject: "internal"
+                _buildDefinitionId: 286
+                _githubRepoName: "installer"
+                _azdoToken: $(dn-bot-dnceng-build-rw-code-rw)
+                _optionalParameters: "-azdoRepoName 'dotnet-installer' -subscribedBranchName 'master'"
+          steps:
+            - checkout: self
+              clean: true
+            - powershell: eng\validation\build-arcadewithrepo.ps1
+                -azdoOrg $(_azdoOrg)
+                -azdoProject $(_azdoProject)
+                -buildDefinitionId $(_buildDefinitionId)
+                -azdoToken $(_azdoToken)
+                -githubUser "dotnet-bot"
+                -githubPAT $(BotAccount-dotnet-bot-repo-PAT)
+                -githubOrg "dotnet"
+                -githubRepoName $(_githubRepoName)
+                -barToken $(MaestroAccessToken)
+                $(_optionalParameters)
+              name: buildarcade

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,216 +43,56 @@ resources:
     image: microsoft/dotnet-buildtools-prereqs:ubuntu-14.04-cross-0cd4667-20170319080304
 
 stages:
-- stage: build
-  displayName: Build
+# Arcade validation with additional repos
+- stage: Validate_Arcade_With_Consumer_Repositories
+  displayName: Validate Arcade with Consumer Repositories
   jobs:
-  - template: /eng/common/templates/jobs/jobs.yml
-    parameters:
-      enableMicrobuild: true
-      enablePublishBuildArtifacts: true
-      enablePublishBuildAssets: true
-      enablePublishUsingPipelines: ${{ variables._PublishUsingPipelines }}
-      enableTelemetry: true
-      helixRepo: dotnet/arcade-validation
-      jobs:
-      - job: Windows_NT
-        pool:
-          name: $(PoolProvider) # This is a queue-time parameter; Public default is NetCorePublic-Pool; Internal default is NetCoreInternal-Pool
-          ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-            queue: BuildPool.Server.Amd64.VS2017.Arcade.Open
-          ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-            queue: BuildPool.Server.Amd64.VS2017.Arcade
+    - template: /eng/common/templates/job/job.yml
+      parameters:
+        name: Validate_Arcade_With_Consumer_Repositories
+        displayName: Validate Arcade with Consumer Repositories
+        timeoutInMinutes: 240
         variables:
-        - _InternalBuildArgs: ''
-
-        # Only enable publishing in non-public, non PR scenarios.
-        - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-          - _InternalBuildArgs: /p:DotNetSignType=$(_SignType) 
-              /p:TeamName=$(_TeamName)
-              /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
-              /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
-
+          - group: Publish-Build-Assets
+          - group: DotNetBot-GitHub
+          - group: DotNet-Blob-Feed
+          - group: DotNet-Symbol-Server-Pats
+          - group: DotNet-VSTS-Infra-Access
         strategy:
           matrix:
-            Build_Release:
-              _BuildConfig: Release
-              # PRs or external builds are not signed.
-              ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-                _SignType: test
-              ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-                _SignType: real
-            ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-              Build_Debug:
-                _BuildConfig: Debug
-                _SignType: test
+            ValidateWithRuntime:
+              _azdoOrg: "dnceng"
+              _azdoProject: "internal"
+              _buildDefinitionId: 679
+              _githubRepoName: "runtime"
+              _azdoToken: $(dn-bot-dnceng-build-rw-code-rw)
+              _optionalParameters: "-azdoRepoName 'dotnet-runtime' -subscribedBranchName 'master'"
+            ValidateWithASPNETCore:
+              _azdoOrg: "dnceng"
+              _azdoProject: "internal"
+              _buildDefinitionId: 21
+              _githubRepoName: "aspnetcore"
+              _azdoToken: $(dn-bot-dnceng-build-rw-code-rw)
+              _optionalParameters: "-azdoRepoName 'dotnet-aspnetcore' -subscribedBranchName 'master'"
+            ValidateWithInstaller:
+              _azdoOrg: "dnceng"
+              _azdoProject: "internal"
+              _buildDefinitionId: 286
+              _githubRepoName: "installer"
+              _azdoToken: $(dn-bot-dnceng-build-rw-code-rw)
+              _optionalParameters: "-azdoRepoName 'dotnet-installer' -subscribedBranchName 'master'"
         steps:
-        - checkout: self
-          clean: true
-        # Use utility script to run script command dependent on agent OS.
-        - script: eng\common\cibuild.cmd
-            -configuration $(_BuildConfig) 
-            -prepareMachine
-            $(_InternalBuildArgs)
-          displayName: Windows Build / Publish
-
-      - job: Linux
-        container: LinuxContainer
-        pool:
-          ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-            name: $(PoolProvider) # This is a queue-time parameter; Public default is NetCorePublic-Pool; Internal default is NetCoreInternal-Pool
-            queue: BuildPool.Ubuntu.1604.Amd64.Arcade.Open
-          ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-            name: Hosted Ubuntu 1604
-        strategy:
-          matrix:
-            Build_Debug:
-              _BuildConfig: Debug
-              _SignType: none
-            Build_Release:
-              _BuildConfig: Release
-              _SignType: none
-        steps:
-        - checkout: self
-          clean: true
-        - script: eng/common/cibuild.sh
-            --configuration $(_BuildConfig)
-            --prepareMachine
-          displayName: Unix Build / Publish
-
-      - job: Validate_Helix
-        variables:
-        - HelixApiAccessToken: ''
-        - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-          - group: DotNet-HelixApi-Access
-        - _BuildConfig: Release
-        steps:
-        - template: /eng/common/templates/steps/send-to-helix.yml
-          parameters:
-            HelixType: test/product/
-            XUnitProjects: $(Build.SourcesDirectory)/src/Validation/tests/Validation.Tests.csproj
-            XUnitTargetFramework: netcoreapp2.0
-            XUnitRunnerVersion: 2.4.1
-            IncludeDotNetCli: true
-            DotNetCliPackageType: sdk
-            DotNetCliVersion: 2.1.403
-            EnableXUnitReporter: true
-            WaitForWorkItemCompletion: true
-            ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-              HelixTargetQueues: Windows.10.Amd64.Arcade.Open;Debian.9.Amd64.Arcade.Open
-              HelixSource: pr/dotnet/arcade-validation/$(Build.SourceBranch)
-              IsExternal: true
-              Creator: arcade-validation
-            ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-              HelixTargetQueues: Windows.10.Amd64.Arcade;Debian.9.Amd64.Arcade
-              HelixSource: official/dotnet/arcade-validation/$(Build.SourceBranch)
-              HelixAccessToken: $(HelixApiAccessToken)
-        displayName: Validate Helix
-
-  # Jobs that should only run as part of internal builds.
-      - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-        - job: Validate_Signing
-          pool: 
-            name: $(PoolProvider) # This is a queue-time parameter; Public default is NetCorePublic-Pool; Internal default is NetCoreInternal-Pool
-            queue: BuildPool.Server.Amd64.VS2017.Arcade
-          strategy:
-            matrix:
-              Test_Signing:
-                _BuildConfig: Debug
-                _SignType: test
-              Real_Signing:
-                _BuildConfig: Release
-                _SignType: real
-          steps:
-            - checkout: self
-              clean: true
-            - task: CopyFiles@2
-              displayName: Copy test packages to artifacts directory
-              inputs:
-                sourceFolder: $(Build.SourcesDirectory)\src\validation\resources
-                targetFolder: $(Build.SourcesDirectory)\artifacts\packages\$(_BuildConfig)\NonShipping
-            - powershell: eng\common\build.ps1
-                -configuration $(_BuildConfig)
-                -restore
-                -prepareMachine
-                -sign
-                -ci
-                /p:DotNetSignType=$(_SignType)
-                /p:TeamName=DotNetCore
-                /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
-              displayName: Sign packages
-
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-  - template: eng\common\templates\post-build\post-build.yml
-    parameters:
-      # Symbol validation isn't being very reliable lately. This should be enabled back
-      # once this issue is resolved: https://github.com/dotnet/arcade/issues/2871
-      enableSymbolValidation: false
-      # Sourcelink validation isn't passing for Arcade-validation. This should be
-      # enabled back once this issue is resolved: https://github.com/dotnet/arcade/issues/3069
-      enableSourceLinkValidation: false
-      # This is to enable SDL runs part of Post-Build Validation Stage
-      SDLValidationParameters:
-        enable: true
-        params: ' -SourceToolsList @("policheck","credscan")
-        -TsaInstanceURL $(_TsaInstanceURL)
-        -TsaProjectName $(_TsaProjectName)
-        -TsaNotificationEmail $(_TsaNotificationEmail)
-        -TsaCodebaseAdmin $(_TsaCodebaseAdmin)
-        -TsaBugAreaPath $(_TsaBugAreaPath)
-        -TsaIterationPath $(_TsaIterationPath)
-        -TsaRepositoryName "Arcade-Validation"
-        -TsaCodebaseName "Arcade-Validation"
-        -TsaPublish $True'
-  # Arcade validation with additional repos
-  - stage: Validate_Arcade_With_Consumer_Repositories
-    displayName: Validate Arcade with Consumer Repositories
-    jobs:
-      - template: /eng/common/templates/job/job.yml
-        parameters:
-          name: Validate_Arcade_With_Consumer_Repositories
-          displayName: Validate Arcade with Consumer Repositories
-          timeoutInMinutes: 240
-          variables:
-            - group: Publish-Build-Assets
-            - group: DotNetBot-GitHub
-            - group: DotNet-Blob-Feed
-            - group: DotNet-Symbol-Server-Pats
-            - group: DotNet-VSTS-Infra-Access
-          strategy:
-            matrix:
-              ValidateWithRuntime:
-                _azdoOrg: "dnceng"
-                _azdoProject: "internal"
-                _buildDefinitionId: 679
-                _githubRepoName: "runtime"
-                _azdoToken: $(dn-bot-dnceng-build-rw-code-rw)
-                _optionalParameters: "-azdoRepoName 'dotnet-runtime' -subscribedBranchName 'master'"
-              ValidateWithASPNETCore:
-                _azdoOrg: "dnceng"
-                _azdoProject: "internal"
-                _buildDefinitionId: 21
-                _githubRepoName: "aspnetcore"
-                _azdoToken: $(dn-bot-dnceng-build-rw-code-rw)
-                _optionalParameters: "-azdoRepoName 'dotnet-aspnetcore' -subscribedBranchName 'master'"
-              ValidateWithInstaller:
-                _azdoOrg: "dnceng"
-                _azdoProject: "internal"
-                _buildDefinitionId: 286
-                _githubRepoName: "installer"
-                _azdoToken: $(dn-bot-dnceng-build-rw-code-rw)
-                _optionalParameters: "-azdoRepoName 'dotnet-installer' -subscribedBranchName 'master'"
-          steps:
-            - checkout: self
-              clean: true
-            - powershell: eng\validation\build-arcadewithrepo.ps1
-                -azdoOrg $(_azdoOrg)
-                -azdoProject $(_azdoProject)
-                -buildDefinitionId $(_buildDefinitionId)
-                -azdoToken $(_azdoToken)
-                -githubUser "dotnet-bot"
-                -githubPAT $(BotAccount-dotnet-bot-repo-PAT)
-                -githubOrg "dotnet"
-                -githubRepoName $(_githubRepoName)
-                -barToken $(MaestroAccessToken)
-                $(_optionalParameters)
-              name: buildarcade
+          - checkout: self
+            clean: true
+          - powershell: eng\validation\build-arcadewithrepo.ps1
+              -azdoOrg $(_azdoOrg)
+              -azdoProject $(_azdoProject)
+              -buildDefinitionId $(_buildDefinitionId)
+              -azdoToken $(_azdoToken)
+              -githubUser "dotnet-bot"
+              -githubPAT $(BotAccount-dotnet-bot-repo-PAT)
+              -githubOrg "dotnet"
+              -githubRepoName $(_githubRepoName)
+              -barToken $(MaestroAccessToken)
+              $(_optionalParameters)
+            name: buildarcade

--- a/eng/validation/build-arcadewithrepo.ps1
+++ b/eng/validation/build-arcadewithrepo.ps1
@@ -49,11 +49,10 @@ function Get-LatestBuildSha()
     ## Verified that this API gets completed builds, not in progress builds
     $headers = Get-AzDOHeaders
     $uri = "https://dev.azure.com/${global:azdoOrg}/${global:azdoProject}/_apis/build/latest/${global:buildDefinitionId}?branchName=${global:subscribedBranchName}&api-version=5.1-preview.1"
-    
-    Write-host "DEBUG: URI: ${uri}"
     $response = (Invoke-WebRequest -Uri $uri -Headers $headers -Method Get) | ConvertFrom-Json
 
     ## Is it successful or partially successful? Then use that as the foundation for our branch. 
+    ## How do we want to handle cancelled builds? 
     if(($response.result -eq "succeeded") -or ($response.result -eq "partiallySucceeded"))
     {
         if("" -eq $response.triggerInfo)
@@ -68,8 +67,8 @@ function Get-LatestBuildSha()
     ## If not, then bail out and don't attempt to validate
     else 
     {
-        Write-Warning "The latest build on '${global:subscribedBranchName}' branch for the '${global:githubRepoName}' repository was not successful."
         Write-Host "##vso[task.setvariable variable=buildStatus;isOutput=true]NoLKG"
+        Write-Error "The latest build on '${global:subscribedBranchName}' branch for the '${global:githubRepoName}' repository was not successful."        
         Exit
     }
 }

--- a/eng/validation/build-arcadewithrepo.ps1
+++ b/eng/validation/build-arcadewithrepo.ps1
@@ -52,7 +52,6 @@ function Get-LatestBuildSha()
     $response = (Invoke-WebRequest -Uri $uri -Headers $headers -Method Get) | ConvertFrom-Json
 
     ## Is it successful or partially successful? Then use that as the foundation for our branch. 
-    ## How do we want to handle cancelled builds? 
     if(($response.result -eq "succeeded") -or ($response.result -eq "partiallySucceeded"))
     {
         if("" -eq $response.triggerInfo)

--- a/eng/validation/build-arcadewithrepo.ps1
+++ b/eng/validation/build-arcadewithrepo.ps1
@@ -34,6 +34,7 @@ $global:barToken = $barToken
 $global:buildParameters = if (-not $buildParameters) { "" } else { $buildParameters }
 $global:pushBranchToGithub = $pushBranchToGithub
 $global:azdoRepoName = if (-not $azdoRepoName) { "" } else { $azdoRepoName }
+$global:subscribedBranchName = $subscribedBranchName
 
 Write-Host "##vso[task.setvariable variable=arcadeVersion;isOutput=true]${global:arcadeSdkVersion}"
 Write-Host "##vso[task.setvariable variable=qualifiedRepoName;isOutput=true]${global:githubOrg}/${global:githubRepoName}"

--- a/eng/validation/build-arcadewithrepo.ps1
+++ b/eng/validation/build-arcadewithrepo.ps1
@@ -48,6 +48,8 @@ function Get-LatestBuildSha()
     ## Verified that this API gets completed builds, not in progress builds
     $headers = Get-AzDOHeaders
     $uri = "https://dev.azure.com/${global:azdoOrg}/${global:azdoProject}/_apis/build/latest/${global:buildDefinitionId}?branchName=${global:subscribedBranchName}&api-version=5.1-preview.1"
+    
+    Write-host "DEBUG: URI: ${uri}"
     $reponse = (Invoke-WebRequest -Uri $uri -Headers $headers -Method Get) | ConvertFrom-Json
 
     ## Is it successful or partially successful? Then use that as the foundation for our branch. 

--- a/eng/validation/build-arcadewithrepo.ps1
+++ b/eng/validation/build-arcadewithrepo.ps1
@@ -51,7 +51,7 @@ function Get-LatestBuildSha()
     $uri = "https://dev.azure.com/${global:azdoOrg}/${global:azdoProject}/_apis/build/latest/${global:buildDefinitionId}?branchName=${global:subscribedBranchName}&api-version=5.1-preview.1"
     
     Write-host "DEBUG: URI: ${uri}"
-    $reponse = (Invoke-WebRequest -Uri $uri -Headers $headers -Method Get) | ConvertFrom-Json
+    $response = (Invoke-WebRequest -Uri $uri -Headers $headers -Method Get) | ConvertFrom-Json
 
     ## Is it successful or partially successful? Then use that as the foundation for our branch. 
     if(($response.result -eq "succeeded") -or ($response.result -eq "partiallySucceeded"))

--- a/eng/validation/build-arcadewithrepo.ps1
+++ b/eng/validation/build-arcadewithrepo.ps1
@@ -9,7 +9,6 @@ Param(
   [Parameter(Mandatory=$true)][string] $githubRepoName,
   [Parameter(Mandatory=$true)][string] $barToken, 
   [string] $buildParameters = '',
-  [int] $daysOfOldestBuild = 3,
   [switch] $pushBranchToGithub,
   [string] $azdoRepoName,
   [string] $subscribedBranchName
@@ -33,7 +32,6 @@ $global:githubOrg = $githubOrg
 $global:githubRepoName = $githubRepoName
 $global:barToken = $barToken
 $global:buildParameters = if (-not $buildParameters) { "" } else { $buildParameters }
-$global:daysOfOldestBuild = if (-not $daysOfOldestBuild) { 3 } else { $daysOfOldestBuild }
 $global:pushBranchToGithub = $pushBranchToGithub
 $global:azdoRepoName = if (-not $azdoRepoName) { "" } else { $azdoRepoName }
 
@@ -45,64 +43,31 @@ $testRootBase = if ($env:AGENT_WORKFOLDER) { $env:AGENT_WORKFOLDER } else { $([S
 $testRoot = Join-Path -Path $testRootBase -ChildPath $([System.IO.Path]::GetRandomFileName())
 New-Item -Path $testRoot -ItemType Directory | Out-Null
 
-$global:minTime = (Get-Date).AddDays(-$global:daysOfOldestBuild)
-$global:buildReasonsList = @("batchedCI", "individualCI", "manual")
-$global:buildSuccessResultList = @("succeeded", "partiallySucceeded")
-
-function Get-LastKnownGoodBuildSha()
+function Get-LatestBuildSha()
 {
-    ## Have there been any builds in the last $daysOfOldestBuild days? 
+    ## Verified that this API gets completed builds, not in progress builds
     $headers = Get-AzDOHeaders
-    $count = 0
+    $uri = "https://dev.azure.com/${global:azdoOrg}/${global:azdoProject}/_apis/build/latest/${global:buildDefinitionId}?branchName=${global:subscribedBranchName}&api-version=5.1-preview.1"
+    $reponse = (Invoke-WebRequest -Uri $uri -Headers $headers -Method Get) | ConvertFrom-Json
 
-    foreach($reason in $global:buildReasonsList)
+    ## Is it successful or partially successful? Then use that as the foundation for our branch. 
+    if(($response.result -eq "succeeded") -or ($response.result -eq "partiallySucceeded"))
     {
-        $uri = Get-AzDOBuildUri -queryStringParameters "&statusFilter=completed&definitions=${global:buildDefinitionId}&reasonFilter=${reason}&minTime=${global:minTime}&branchName=${global:subscribedBranchName}&`$top=1"
-        $reponse = (Invoke-WebRequest -Uri $uri -Headers $headers -Method Get) | ConvertFrom-Json
-        $count += $reponse.count
-    }
-
-    ## No? Then get the last known good build regardless of age
-    if($count -eq 0)
-    {
-        $contentArray = Get-Builds
-        if($null -eq $contentArray)
+        if("" -eq $response.triggerInfo)
         {
-            Write-Warning "There were no successful builds on the '${global:subscribedBranchName}' branch for the '${global:githubRepoName}' repository."
+            return $response.sourceVersion
         }
-        
-        if("" -eq ($contentArray | Sort-Object { $_.value.finishTime } -descending)[0].value.triggerInfo)
+        else 
         {
-            return ($contentArray | Sort-Object { $_.value.finishTime } -descending)[0].value.sourceVersion
-        }
-        else
-        {
-            return ($contentArray | Sort-Object { $_.value.finishTime } -descending)[0].value.triggerInfo.'ci.sourceSha'
+            return $response.triggerInfo.'ci.sourceSha'
         }
     }
-
-    ## If there have been builds in the last $global:daysOfOldestBuild days, get the last known good build from that time frame
-    else
+    ## If not, then bail out and don't attempt to validate
+    else 
     {
-        $count = 0
-        $contentArray = Get-Builds -useMinTime
-        ## If there are no last known good builds in the last $global:daysOfOldestBuild days, then write a warning. 
-        $contentArray | Foreach-Object {$count += $_.count}
-        if($count -eq 0)
-        {
-            Write-Host "##vso[task.setvariable variable=buildStatus;isOutput=true]NoLKG"
-            Write-Error "There were no successful builds on the '${global:subscribedBranchName}' branch for the '${global:githubRepoName}' repository in the last ${global:daysOfOldestBuild} days."
-            Exit
-        }
-
-        if("" -eq ($contentArray | Sort-Object { $_.value.finishTime } -descending)[0].value.triggerInfo)
-        {
-            return ($contentArray | Sort-Object { $_.value.finishTime } -descending)[0].value.sourceVersion
-        }
-        else
-        {
-            return ($contentArray | Sort-Object { $_.value.finishTime } -descending)[0].value.triggerInfo.'ci.sourceSha'
-        }
+        Write-Warning "The latest build on '${global:subscribedBranchName}' branch for the '${global:githubRepoName}' repository was not successful."
+        Write-Host "##vso[task.setvariable variable=buildStatus;isOutput=true]NoLKG"
+        Exit
     }
 }
 
@@ -125,34 +90,6 @@ function Invoke-AzDOBuild()
 
     $content = Invoke-WebRequest -Uri $uri -Headers $headers -ContentType "application/json" -Body ($body | ConvertTo-Json) -Method Post 
     return ($content | ConvertFrom-Json).id
-}
-
-function Get-Builds(
-    [switch] $useMinTime
-)
-{
-    $contentArray = @()
-
-    foreach($reason in $global:buildReasonslist)
-    {
-        foreach($result in $global:buildSuccessResultList)
-        {
-            $uri = Get-AzDOBuildUri -queryStringParameters "&resultFilter=${result}&definitions=${global:buildDefinitionId}&reasonFilter=${reason}&branchName=${global:subscribedBranchName}&buildQueryOrder=finishTimeAscending&`$top=1"
-            if($useMinTime)
-            {
-                $uri += "&minTime=${global:minTime}"
-            }
-
-            $response = ((Invoke-WebRequest -Uri $uri -Headers $headers -Method Get) | ConvertFrom-Json)
-
-            if(1 -eq $response.count)
-            {
-                $contentArray += $response
-            }
-        }
-    }
-
-    return $contentArray
 }
 
 function Get-BuildStatus(
@@ -278,9 +215,9 @@ $global:darcAzDORepoName = "https://dev.azure.com/${global:azdoOrg}/${global:azd
 $global:darcRepoName = ""
 $global:subscribedBranchName = if (-not $subscribedBranchName) { "refs/heads/" + (Get-SubscribedBranch) } else { "refs/heads/${subscribedBranchName}" }
 
-## If able to retrieve a build, get the SHA that it was built from
-$sha = Get-LastKnownGoodBuildSha
-Write-Host "Last Known Good Build SHA: ${sha}"
+## If able to retrieve the latest build, get the SHA that it was built from
+$sha = Get-LatestBuildSha
+Write-Host "Lastest Build SHA: ${sha}"
 
 ## Clone the repo from git
 Write-Host "Cloning '${global:githubRepoName} from GitHub"


### PR DESCRIPTION
We'll use the Latest Build endpoint from AzDO's API to determine if we should validate Arcade against the repo. If the Latest Build result is "partiallySucceeded" or "succeeded", then we'll use the SHA of that build to build Arcade with in that repo. If the result is "cancelled" or "failed", then we won't validate Arcade with that repo. 