### PR TITLE
Including 'Validate Publishing' stage

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -203,6 +203,29 @@ stages:
         -TsaRepositoryName "Arcade-Validation"
         -TsaCodebaseName "Arcade-Validation"
         -TsaPublish $True'
+  - stage: Validate_Publishing
+    displayName: Validate Publishing
+    jobs: 
+    - template: /eng/common/templates/post-build/setup-maestro-vars.yml
+    - template: /eng/common/templates/job/job.yml
+      parameters:
+        name: Validate_Publishing
+        displayName: Validate Publishing
+        dependsOn: setupMaestroVars
+        timeoutInMinutes: 240
+        pool: 
+          vmImage: vs2017-win2016
+        variables:
+          - group: Publish-Build-Assets
+          - name: BARBuildId
+            value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.BARBuildId'] ]
+        steps:
+          - checkout: self
+            clean: true
+          - powershell: eng\validation\test-publishing.ps1
+              -buildId $(BARBuildId)
+              -azdoToken $(dn-bot-dnceng-build-rw-code-rw)
+              -barToken $(MaestroAccessToken)
   # Arcade validation with additional repos
   - stage: Validate_Arcade_With_Consumer_Repositories
     displayName: Validate Arcade with Consumer Repositories

--- a/eng/validation/test-publishing.ps1
+++ b/eng/validation/test-publishing.ps1
@@ -1,0 +1,56 @@
+Param(
+  [Parameter(Mandatory=$true)][string] $buildId,
+  [Parameter(Mandatory=$true)][string] $azdoToken,
+  [Parameter(Mandatory=$true)][string] $barToken
+)
+
+set-strictmode -version 2.0
+$ErrorActionPreference = 'Stop'
+
+. $PSScriptRoot\..\common\darc-init.ps1
+
+$global:buildId = $buildId
+$global:targetChannel = "General Testing"
+$global:azdoToken = $azdoToken
+$global:barToken = $barToken
+
+function Find-BuildInTargetChannel(
+    [string] $buildId,
+    [string] $targetChannelName
+)
+{
+    $buildJson = darc get-build --id $buildId --azdev-pat $global:azdoToken --password $global:barToken --output-format json
+    $build = ($buildJson | ConvertFrom-Json)
+
+    $channels = ($build | Select-Object -ExpandProperty channels)
+    if($channels -contains $targetChannelName)
+    {
+        return $true
+    }
+
+    return $false
+}
+
+# Verify that the build doesn't already exist in our target channel (otherwise we cannot verify that it was published correctly)
+Write-Host "Verifying that build '${global:buildId}' does not exist in channel '${global:targetChannel}'"
+$preCheck = (Find-BuildInTargetChannel -buildId $global:buildId -targetChannelName $global:targetChannel)
+if($preCheck)
+{
+    Write-Error "Build already exists in '${global:targetChannel}'."
+}
+
+Write-Host "Adding build '${global:buildId}' to channel '${global:targetChannel}'"
+& darc add-build-to-channel --id $global:buildId --channel $global:targetChannel --azdev-pat $global:azdoToken --password $global:barToken
+
+if ($LastExitCode -ne 0) {
+    Write-Host "Problems using Darc to promote build '${global:buildId}' to channel '${global:targetChannel}'. Stopping execution..."
+    exit 1
+}
+
+# Validate that the build was added to the target channel. 
+Write-Host "Verifying that build '${global:buildId}' was added in channel '${global:targetChannel}'"
+$postCheck = (Find-BuildInTargetChannel -buildId $global:buildId -targetChannelName $global:targetChannel)
+if(-not $postCheck)
+{
+    Write-Error "Build was not added to '${global:targetChannel}'."
+}


### PR DESCRIPTION
This adds a stage to Arcade Validation to publish itself to General Testing channel, in order to test publishing. 

Validated here: https://dnceng.visualstudio.com/internal/_build/results?buildId=703497&view=logs&j=56ebfe15-69d8-5dd1-65e4-c65998c8d8a6&t=0a9483a6-3ac1-5fd2-c450-3586b050b65b

