### PR TITLE
Stop producing package for Validation.Tests

### DIFF
--- a/src/Validation/tests/Validation.Tests.csproj
+++ b/src/Validation/tests/Validation.Tests.csproj
@@ -2,6 +2,5 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <IsPackable>true</IsPackable>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This is preparation for when we update the version of the Microsoft.NET.Test.Sdk in Arcade. Part of https://github.com/dotnet/arcade/issues/5291