### PR TITLE
Add Setup private feeds credentials during official build stage

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -9,8 +9,12 @@
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  <!-- these two feeds are only added to test functionality in the SetupNuGetSources scripts -->
+    <add key="darc-int-dotnet-corefx-059a4a1" value="https://pkgs.dev.azure.com/dnceng/_packaging/darc-int-dotnet-corefx-059a4a19/nuget/v3/index.json" />
+    <add key="fake-source-will-break-if-enabled" value="https://fake-source/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
-    <clear />
+    <add key="fake-source-will-break-if-enabled" value="true"/>
+    <add key="darc-int-dotnet-corefx-059a4a1" value="true"/>
   </disabledPackageSources>
 </configuration>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,6 +4,7 @@ variables:
   - name: _PublishUsingPipelines
     value: true
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    - group: AzureDevOps-Artifact-Feeds-Pats
     - group: SDL_Settings
   - ${{ if and(eq(variables.PoolProvider, ''), eq(variables['System.TeamProject'], 'public')) }}:
     - name: PoolProvider
@@ -88,6 +89,15 @@ stages:
         steps:
         - checkout: self
           clean: true
+        - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+          - task: PowerShell@2
+            displayName: Setup Private Feeds Credentials
+            condition: eq(variables['Agent.OS'], 'Windows_NT')
+            inputs:
+              filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
+              arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
+            env:
+              Token: $(dn-bot-dnceng-artifact-feeds-rw)
         # Use utility script to run script command dependent on agent OS.
         - script: eng\common\cibuild.cmd
             -configuration $(_BuildConfig) 
@@ -114,6 +124,15 @@ stages:
         steps:
         - checkout: self
           clean: true
+        - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+          - task: Bash@3
+            displayName: Setup Private Feeds Credentials
+            inputs:
+              filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.sh
+              arguments: $(Build.SourcesDirectory)/NuGet.config $Token
+            condition: ne(variables['Agent.OS'], 'Windows_NT')
+            env:
+              Token: $(dn-bot-dnceng-artifact-feeds-rw)
         - script: eng/common/cibuild.sh
             --configuration $(_BuildConfig)
             --prepareMachine


### PR DESCRIPTION
https://github.com/dotnet/arcade/issues/5788 and some validation for https://github.com/dotnet/arcade/issues/5890

* Add build steps to run the SetupNugetSources scripts in linux and windows builds.
* Add a fake source that the scripts should not re-enable as it will cause nuget to die
* Add a real source that the logs should show is re-enabled.

Some additional validation to make sure the nuget.config file looks as expected should be added to complete the validation.

Test build: https://dnceng.visualstudio.com/internal/_build/results?buildId=758611&view=results