### PR TITLE
Use SetupNugetSources scripts during official build 

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -12,8 +12,12 @@
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="symreader-converter" value="https://dotnet.myget.org/F/symreader-converter/api/v3/index.json" />
     <add key="symreader" value="https://dotnet.myget.org/F/symreader/api/v3/index.json" />
+    <!-- these two feeds are only added to test functionality in the SetupNuGetSources scripts -->
+    <add key="darc-int-dotnet-corefx-059a4a1" value="https://pkgs.dev.azure.com/dnceng/_packaging/darc-int-dotnet-corefx-059a4a19/nuget/v3/index.json" />
+    <add key="fake-source-will-break-if-enabled" value="https://fake-source/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
-    <clear />
+    <add key="fake-source-will-break-if-enabled" value="true"/>
+    <add key="darc-int-dotnet-corefx-059a4a1" value="true"/>
   </disabledPackageSources>
 </configuration>

--- a/NuGet.config
+++ b/NuGet.config
@@ -6,13 +6,9 @@
   <!-- Only specify feed for Arcade SDK (see https://github.com/Microsoft/msbuild/issues/2982) -->
   <packageSources>
     <clear />
-    <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
-    <add key="arcade-validation" value="https://dotnetfeed.blob.core.windows.net/arcade-validation/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="symreader-converter" value="https://dotnet.myget.org/F/symreader-converter/api/v3/index.json" />
-    <add key="symreader" value="https://dotnet.myget.org/F/symreader/api/v3/index.json" />
     <!-- these two feeds are only added to test functionality in the SetupNuGetSources scripts -->
     <add key="darc-int-dotnet-corefx-059a4a1" value="https://pkgs.dev.azure.com/dnceng/_packaging/darc-int-dotnet-corefx-059a4a19/nuget/v3/index.json" />
     <add key="fake-source-will-break-if-enabled" value="https://fake-source/nuget/v3/index.json" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -7,6 +7,7 @@
   <packageSources>
     <clear />
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
+    <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
     <add key="arcade-validation" value="https://dotnetfeed.blob.core.windows.net/arcade-validation/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,6 +9,7 @@ variables:
     value: .NETCoreValidation
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - group: SDL_Settings
+    - group: AzureDevOps-Artifact-Feeds-Pats
 
 trigger:
   batch: true
@@ -77,6 +78,15 @@ stages:
         steps:
         - checkout: self
           clean: true
+        - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+          - task: PowerShell@2
+            displayName: Setup Private Feeds Credentials
+            condition: eq(variables['Agent.OS'], 'Windows_NT')
+            inputs:
+              filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
+              arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
+            env:
+              Token: $(dn-bot-dnceng-artifact-feeds-rw)
         # Use utility script to run script command dependent on agent OS.
         - script: eng\common\cibuild.cmd
             -configuration $(_BuildConfig) 
@@ -106,6 +116,15 @@ stages:
         steps:
         - checkout: self
           clean: true
+        - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+          - task: Bash@3
+            displayName: Setup Private Feeds Credentials
+            inputs:
+              filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.sh
+              arguments: $(Build.SourcesDirectory)/NuGet.config $Token
+            condition: ne(variables['Agent.OS'], 'Windows_NT')
+            env:
+              Token: $(dn-bot-dnceng-artifact-feeds-rw)
         - script: eng/common/cibuild.sh
             --configuration $(_BuildConfig)
             --prepareMachine


### PR DESCRIPTION
dotnet/arcade#5788 and some validation for dotnet/arcade#5890 for the release/3.x branch

Add build steps to run the SetupNugetSources scripts in linux and windows builds.
Add a fake source that the scripts should not re-enable as it will cause nuget to die
Add a real source that the logs should show is re-enabled.

Clean up the nuget.config

Test build: https://dnceng.visualstudio.com/internal/_build/results?buildId=758685&view=results

The errors in the windows release configuration are due to missing the fix from https://github.com/dotnet/arcade/pull/5897