### PR TITLE
Only do validate_publishing if the branch being built is master

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -223,33 +223,34 @@ stages:
         -TsaRepositoryName "Arcade-Validation"
         -TsaCodebaseName "Arcade-Validation"
         -TsaPublish $True'
-  - stage: Validate_Publishing
-    displayName: Validate Publishing
-    jobs: 
-    - template: /eng/common/templates/post-build/setup-maestro-vars.yml
-    - template: /eng/common/templates/job/job.yml
-      parameters:
-        name: Validate_Publishing
-        displayName: Validate Publishing
-        dependsOn: setupMaestroVars
-        timeoutInMinutes: 240
-        pool: 
-          vmImage: vs2017-win2016
-        variables:
-          - group: Publish-Build-Assets
-          - group: DotNetBot-GitHub
-          - name: BARBuildId
-            value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.BARBuildId'] ]
-        steps:
-          - checkout: self
-            clean: true
-          - powershell: eng\validation\test-publishing.ps1
-              -buildId $(BARBuildId)
-              -azdoToken $(dn-bot-dnceng-build-rw-code-rw)
-              -githubUser "dotnet-bot"
-              -githubOrg "dotnet"
-              -barToken $(MaestroAccessToken)
-              -githubPAT $(BotAccount-dotnet-bot-repo-PAT)
+  - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/master') }}:
+    - stage: Validate_Publishing
+      displayName: Validate Publishing
+      jobs: 
+      - template: /eng/common/templates/post-build/setup-maestro-vars.yml
+      - template: /eng/common/templates/job/job.yml
+        parameters:
+          name: Validate_Publishing
+          displayName: Validate Publishing
+          dependsOn: setupMaestroVars
+          timeoutInMinutes: 240
+          pool: 
+            vmImage: vs2017-win2016
+          variables:
+            - group: Publish-Build-Assets
+            - group: DotNetBot-GitHub
+            - name: BARBuildId
+              value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.BARBuildId'] ]
+          steps:
+            - checkout: self
+              clean: true
+            - powershell: eng\validation\test-publishing.ps1
+                -buildId $(BARBuildId)
+                -azdoToken $(dn-bot-dnceng-build-rw-code-rw)
+                -githubUser "dotnet-bot"
+                -githubOrg "dotnet"
+                -barToken $(MaestroAccessToken)
+                -githubPAT $(BotAccount-dotnet-bot-repo-PAT)
   # Arcade validation with additional repos
   - stage: Validate_Arcade_With_Consumer_Repositories
     displayName: Validate Arcade with Consumer Repositories


### PR DESCRIPTION
This will prevent issues when validating private arcade versions.

https://github.com/dotnet/arcade/issues/6313

Test build: https://dnceng.visualstudio.com/internal/_build/results?buildId=847354&view=results