### PR TITLE
Promote build automatically to .net 5 eng

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -224,85 +224,47 @@ stages:
         -TsaRepositoryName "Arcade-Validation"
         -TsaCodebaseName "Arcade-Validation"
         -TsaPublish $True'
-  - stage: Validate_Publishing
-    displayName: Validate Publishing
-    jobs: 
-    - template: /eng/common/templates/post-build/setup-maestro-vars.yml
-    - template: /eng/common/templates/job/job.yml
-      parameters:
-        name: Validate_Publishing
-        displayName: Validate Publishing
-        dependsOn: setupMaestroVars
-        timeoutInMinutes: 240
-        pool: 
-          vmImage: vs2017-win2016
-        variables:
-          - group: Publish-Build-Assets
-          - group: DotNetBot-GitHub
-          - name: BARBuildId
-            value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.BARBuildId'] ]
-        steps:
-          - checkout: self
-            clean: true
-          - powershell: eng\validation\test-publishing.ps1
-              -buildId $(BARBuildId)
-              -azdoToken $(dn-bot-dnceng-build-rw-code-rw)
-              -githubUser "dotnet-bot"
-              -githubOrg "dotnet"
-              -barToken $(MaestroAccessToken)
-              -githubPAT $(BotAccount-dotnet-bot-repo-PAT)
-  # Arcade validation with additional repos
-  - stage: Validate_Arcade_With_Consumer_Repositories
-    displayName: Validate Arcade with Consumer Repositories
-    condition: eq(variables['RunBellwetherRepoBuilds'], 'true')
-    jobs:
+  - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/release/5.0') }}:
+    - stage: Validate_Publishing
+      displayName: Validate Publishing
+      jobs: 
+      - template: /eng/common/templates/post-build/setup-maestro-vars.yml
       - template: /eng/common/templates/job/job.yml
         parameters:
-          name: Validate_Arcade_With_Consumer_Repositories
-          displayName: Validate Arcade with Consumer Repositories
+          name: Validate_Publishing
+          displayName: Validate Publishing
+          dependsOn: setupMaestroVars
           timeoutInMinutes: 240
+          pool: 
+            vmImage: vs2017-win2016
           variables:
             - group: Publish-Build-Assets
             - group: DotNetBot-GitHub
-            - group: DotNet-Blob-Feed
-            - group: DotNet-Symbol-Server-Pats
-            - group: DotNet-VSTS-Infra-Access
-          strategy:
-            matrix:
-              ValidateWithRuntime:
-                _azdoOrg: "dnceng"
-                _azdoProject: "internal"
-                _buildDefinitionId: 679
-                _githubRepoName: "runtime"
-                _azdoToken: $(dn-bot-dnceng-build-rw-code-rw)
-                _optionalParameters: "-azdoRepoName 'dotnet-runtime' -subscribedBranchName 'master'"
-              ValidateWithASPNETCore:
-                _azdoOrg: "dnceng"
-                _azdoProject: "internal"
-                _buildDefinitionId: 21
-                _githubRepoName: "aspnetcore"
-                _azdoToken: $(dn-bot-dnceng-build-rw-code-rw)
-                _optionalParameters: "-azdoRepoName 'dotnet-aspnetcore' -subscribedBranchName 'master'"
-              ValidateWithInstaller:
-                _azdoOrg: "dnceng"
-                _azdoProject: "internal"
-                _buildDefinitionId: 286
-                _githubRepoName: "installer"
-                _azdoToken: $(dn-bot-dnceng-build-rw-code-rw)
-                _optionalParameters: "-azdoRepoName 'dotnet-installer' -subscribedBranchName 'master'"
+            - name: BARBuildId
+              value: $[ dependencies.setupMaestroVars.outputs['setReleaseVars.BARBuildId'] ]
           steps:
             - checkout: self
               clean: true
-            - powershell: eng\validation\build-arcadewithrepo.ps1
-                -azdoOrg $(_azdoOrg)
-                -azdoProject $(_azdoProject)
-                -buildDefinitionId $(_buildDefinitionId)
-                -azdoToken $(_azdoToken)
+            - powershell: eng\validation\test-publishing.ps1
+                -buildId $(BARBuildId)
+                -azdoToken $(dn-bot-dnceng-build-rw-code-rw)
                 -githubUser "dotnet-bot"
-                -githubPAT $(BotAccount-dotnet-bot-repo-PAT)
                 -githubOrg "dotnet"
-                -githubRepoName $(_githubRepoName)
                 -barToken $(MaestroAccessToken)
-                $(_optionalParameters)
-              displayName: Build Bellwether Repo With Arcade
-              name: Build_Bellwether_Repo_With_Arcade
+                -githubPAT $(BotAccount-dotnet-bot-repo-PAT)
+  - stage: Push_to_net5_eng_channel
+    displayName: Push Build to '.NET 5 Eng'
+    variables:
+      - group: Publish-Build-Assets
+    jobs:
+    - template: /eng/common/templates/job/job.yml
+      parameters: 
+        name: Push_to_net5_eng_channel
+        displayname: Add build to '.NET 5 Eng'
+        steps:
+          - checkout: self
+            clean: true
+          - powershell: eng/validation/update-channel.ps1
+              -maestroEndpoint https://maestro-prod.westus2.cloudapp.azure.com
+              -barToken $(MaestroAccessToken)
+            displayName: Move build to '.NET 5 Eng' channel


### PR DESCRIPTION
https://github.com/dotnet/arcade/issues/6390

This change makes it so the official build will promote the arcade build to the .net 5 eng channel automatically.

It takes advantage of the --skip-assets-publishing flag because we don't need to republish any assets.

I also ported the change from https://github.com/dotnet/arcade-validation/pull/1869 so that private builds of the release/5.0 branch don't do the "validate publishing" stage.

Test build (this added the missing build to the channel even) https://dnceng.visualstudio.com/internal/_build/results?buildId=849418&view=results
