### PR TITLE
Use queue name to allow helix redirect

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -157,12 +157,12 @@ stages:
             EnableXUnitReporter: true
             WaitForWorkItemCompletion: true
             ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-              HelixTargetQueues: Windows.10.Amd64.Arcade.Open;Debian.9.Amd64.Arcade.Open
+              HelixTargetQueues: Windows.10.Amd64.Open;Debian.9.Amd64.Open
               HelixSource: pr/dotnet/arcade-validation/$(Build.SourceBranch)
               IsExternal: true
               Creator: arcade-validation
             ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-              HelixTargetQueues: Windows.10.Amd64.Arcade;Debian.9.Amd64.Arcade
+              HelixTargetQueues: Windows.10.Amd64;Debian.9.Amd64
               HelixSource: official/dotnet/arcade-validation/$(Build.SourceBranch)
               HelixAccessToken: $(HelixApiAccessToken)
         displayName: Validate Helix


### PR DESCRIPTION
Now that we have completed dotnet/core-eng#11006 we need to change the names of the queues to allow Helix redirect arcade jobs