### PR TITLE
Handle scenario of no darc updates for a given repo

### DIFF
--- a/eng/validation/build-arcadewithrepo.ps1
+++ b/eng/validation/build-arcadewithrepo.ps1
@@ -45,6 +45,8 @@ $testRootBase = if ($env:AGENT_WORKFOLDER) { $env:AGENT_WORKFOLDER } else { $([S
 $testRoot = Join-Path -Path $testRootBase -ChildPath $([System.IO.Path]::GetRandomFileName())
 New-Item -Path $testRoot -ItemType Directory | Out-Null
 
+Write-Output "Working inside $testRoot"
+
 function Get-LatestBuildSha()
 {
     ## Verified that this API gets completed builds, not in progress builds
@@ -154,7 +156,7 @@ $global:darcRepoName = ""
 $sha = Get-LatestBuildSha
 
 ## Clone the repo from git
-Write-Host "Cloning '${global:githubRepoName} from GitHub"
+Write-Host "Cloning '${global:githubRepoName}' from GitHub"
 GitHub-Clone $global:githubRepoName $global:githubUser $global:githubUri
 
 ## Check to see if branch exists and clean it up if it does
@@ -202,7 +204,15 @@ $barBuildId = ([regex]"\d+").Match($barBuildIdString).Value
 
 ## Make the changes to that branch to update Arcade - use darc
 Set-Location $(Get-Repo-Location $global:githubRepoName)
-& $darc update-dependencies --id $barBuildId --github-pat $global:githubPAT --azdev-pat $global:azdoToken --password $global:bartoken
+
+$darcOutput = & $darc update-dependencies --id $barBuildId --github-pat $global:githubPAT --azdev-pat $global:azdoToken --password $global:bartoken
+Write-Output $darcOutput
+if ($darcOutput -eq "Found no dependencies to update.")
+{
+   ## Log a warning so this isn't hidden, but it's not necessarily a problem either, just exit.
+   Write-Host "##vso[task.logissue type=warning]Darc returned no dependencies to update for this repo"
+   exit 0
+}
 
 Git-Command $global:githubRepoName add -A
 Git-Command $global:githubRepoName commit -am "Arcade Validation test branch - version ${global:arcadeSdkVersion}"

--- a/eng/validation/build-arcadewithrepo.ps1
+++ b/eng/validation/build-arcadewithrepo.ps1
@@ -209,9 +209,9 @@ $darcOutput = & $darc update-dependencies --id $barBuildId --github-pat $global:
 Write-Output $darcOutput
 if ($darcOutput -eq "Found no dependencies to update.")
 {
-   ## Log a warning so this isn't hidden, but it's not necessarily a problem either, just exit.
-   Write-Host "##vso[task.logissue type=warning]Darc returned no dependencies to update for this repo"
-   exit 0
+   ## This needs investigation; fail fast 
+   Write-Host "##vso[task.logissue type=error]Darc returned no dependencies to update for this repo, please investigate why."
+   exit 1
 }
 
 Git-Command $global:githubRepoName add -A

--- a/eng/validation/test-publishing.ps1
+++ b/eng/validation/test-publishing.ps1
@@ -50,7 +50,7 @@ $sha = $jsonAsset.build.commit
 $global:targetBranch = "val/arcade-" + $global:arcadeSdkVersion
 
 ## Clone the repo from git
-Write-Host "Cloning '${global:githubRepoName} from GitHub"
+Write-Host "Cloning '${global:githubRepoName}' from GitHub"
 GitHub-Clone $global:githubRepoName $global:githubUser $global:githubUri
 
 ## Create a branch from the repo with the given SHA.

--- a/eng/validation/validation-functions.ps1
+++ b/eng/validation/validation-functions.ps1
@@ -16,7 +16,8 @@ function Git-Command($repoName) {
             $gitParams = $gitParams.ToString().Split(" ")
         }
         Write-Host "Running 'git $gitParams' from $(Get-Location)"
-        $commandOutput = & git @gitParams; if ($LASTEXITCODE -ne 0) { throw "Git exited with exit code: $LASTEXITCODE" } else { $commandOutput }
+        $commandOutput = & git @gitParams; if ($LASTEXITCODE -ne 0) { throw "Git exited with exit code: $LASTEXITCODE - $commandOutput " } else { $commandOutput }
+
         $commandOutput
     }
     finally {


### PR DESCRIPTION
Since this isn't necessarily indicative of anything wrong, just print warning and exit.  Also print output when we have git errors.

https://github.com/dotnet/core-eng/issues/11993

