### PR TITLE
Move promotion pipeline repo from github to Azure Devops

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -248,8 +248,9 @@ stages:
             - powershell: eng\validation\test-publishing.ps1
                 -buildId $(BARBuildId)
                 -azdoToken $(dn-bot-dotnet-build-rw-code-rw)
-                -githubUser "dotnet-bot"
-                -githubOrg "dotnet"
+                -azdoUser "dotnet-bot"
+                -azdoOrg "dnceng"
+                -azdoProject "internal"
                 -barToken $(MaestroAccessToken)
                 -githubPAT $(BotAccount-dotnet-bot-repo-PAT)
   # Arcade validation with additional repos

--- a/eng/validation/test-publishing.ps1
+++ b/eng/validation/test-publishing.ps1
@@ -1,8 +1,9 @@
 Param(
   [Parameter(Mandatory=$true)][string] $buildId,
   [Parameter(Mandatory=$true)][string] $azdoToken,
-  [Parameter(Mandatory=$true)][string] $githubUser,
-  [Parameter(Mandatory=$true)][string] $githubOrg,
+  [Parameter(Mandatory=$true)][string] $azdoUser,
+  [Parameter(Mandatory=$true)][string] $azdoOrg,
+  [Parameter(Mandatory=$true)][string] $azdoProject,
   [Parameter(Mandatory=$true)][string] $barToken,
   [Parameter(Mandatory=$true)][string] $githubPAT
 )
@@ -17,12 +18,11 @@ $darc = & "$PSScriptRoot\get-darc.ps1"
 $global:buildId = $buildId
 $global:targetChannel = "General Testing"
 $global:azdoToken = $azdoToken
-$global:githubUser = $githubUser
+$global:azdoUser = $azdoUser
+$global:azdoOrg = $azdoOrg
+$global:azdoProject = $azdoProject
 $global:githubPAT = $githubPAT
-$global:githubOrg = $githubOrg
 $global:barToken = $barToken
-$global:githubPAT = $githubPAT
-
 
 function Find-BuildInTargetChannel(
     [string] $buildId,
@@ -43,29 +43,29 @@ function Find-BuildInTargetChannel(
 
 $global:arcadeSdkPackageName = 'Microsoft.DotNet.Arcade.Sdk'
 $global:arcadeSdkVersion = $GlobalJson.'msbuild-sdks'.$global:arcadeSdkPackageName
-$global:githubRepoName = "arcade"
-$global:githubUri = "https://${global:githubUser}:${global:githubPAT}@github.com/${global:githubOrg}/${global:githubRepoName}"
+$global:azdoRepoName = "dotnet-arcade"
+$global:azdoRepoUri = "https://unused:$azdoToken@${global:azdoOrg}.visualstudio.com/${global:azdoProject}/_git/${global:azdoRepoName}"
 $jsonAsset = & $darc get-asset --name $global:arcadeSdkPackageName --version $global:arcadeSdkVersion --github-pat $global:githubPAT --azdev-pat $global:azdoToken --password $global:bartoken --output-format json | convertFrom-Json
 $sha = $jsonAsset.build.commit
 $global:targetBranch = "val/arcade-" + $global:arcadeSdkVersion
 
 ## Clone the repo from git
-Write-Host "Cloning '${global:githubRepoName}' from GitHub"
-GitHub-Clone $global:githubRepoName $global:githubUser $global:githubUri
+Write-Host "Cloning '${global:azdoRepoName}' from Azure Devops"
+GitHub-Clone $global:azdoRepoName $global:azdoUser $global:azdoRepoUri
 
 ## Create a branch from the repo with the given SHA.
-Git-Command $global:githubRepoName checkout -b $global:targetBranch $sha
+Git-Command $global:azdoRepoName checkout -b $global:targetBranch $sha
 
 ## Get the BAR Build ID for the version of Arcade we want to use in update-dependecies
 $barBuildId = $jsonAsset.build.id
 
 ## Make the changes to that branch to update Arcade - use darc
-Set-Location $(Get-Repo-Location $global:githubRepoName)
+Set-Location $(Get-Repo-Location $global:azdoRepoName)
 & $darc update-dependencies --id $barBuildId --github-pat $global:githubPAT --azdev-pat $global:azdoToken --password $global:bartoken
 
-Git-Command $global:githubRepoName commit -am "Arcade branch - version ${global:arcadeSdkVersion}"
+Git-Command $global:azdoRepoName commit -am "Arcade branch - version ${global:arcadeSdkVersion}"
 
-Git-Command $global:githubRepoName push origin HEAD
+Git-Command $global:azdoRepoName push origin HEAD
 
 # Verify that the build doesn't already exist in our target channel (otherwise we cannot verify that it was published correctly)
 Write-Host "Verifying that build '${global:buildId}' does not exist in channel '${global:targetChannel}'"
@@ -80,7 +80,7 @@ Write-Host "Adding build '${global:buildId}' to channel '${global:targetChannel}
 
 if ($LastExitCode -ne 0) {
     Write-Host "Problems using Darc to promote build '${global:buildId}' to channel '${global:targetChannel}'. Stopping execution..."
-	Cleanup-Branch $global:githubRepoName $global:targetBranch
+	Cleanup-Branch $global:azdoRepoName $global:targetBranch
     exit 1
 }
 
@@ -92,4 +92,4 @@ if(-not $postCheck)
     Write-Error "Build was not added to '${global:targetChannel}'."
 }
 
-Cleanup-Branch $global:githubRepoName $global:targetBranch
+Cleanup-Branch $global:azdoRepoName $global:targetBranch


### PR DESCRIPTION
See https://github.com/dotnet/core-eng/issues/12258 for context.  

We are trying not to have dnceng/internal cloning from Github directly, and the pipeline this validation script uses is now explicitly mapped to dnceng/internal. 

@mmitche FYI.

Validated using [this build](https://dnceng.visualstudio.com/internal/_build/results?buildId=1003654&view=logs&s=0d7db6e4-c533-50c8-77c7-b1b9fc049ed6), including making sure that the val/... branch got deleted.