### PR TITLE
Fix logging for validation

### DIFF
--- a/eng/validation/update-channel.ps1
+++ b/eng/validation/update-channel.ps1
@@ -7,6 +7,7 @@ Param(
   [string] $githubToken
 )
 
+$ci = $true
 . $PSScriptRoot\..\common\tools.ps1
 . $PSScriptRoot\..\common\pipeline-logging-functions.ps1
 $darc = & "$PSScriptRoot\get-darc.ps1"


### PR DESCRIPTION
The logging functions require $ci to be $true. Setting this variable causes the lines to output with the necessary vso headers