### PR TITLE
Fix source linking in arcade-validation, and reenable source link validation

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,10 @@
 <Project>
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 
+  <PropertyGroup>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+  </PropertyGroup>
+  
   <PropertyGroup Condition="'$(CopyrightNetFoundation)' != ''">
     <Copyright>$(CopyrightNetFoundation)</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -214,9 +214,7 @@ stages:
       # Symbol validation isn't being very reliable lately. This should be enabled back
       # once this issue is resolved: https://github.com/dotnet/arcade/issues/2871
       enableSymbolValidation: false
-      # Sourcelink validation isn't passing for Arcade-validation. This should be
-      # enabled back once this issue is resolved: https://github.com/dotnet/arcade/issues/3069
-      enableSourceLinkValidation: false
+      enableSourceLinkValidation: true
       # This is to enable SDL runs part of Post-Build Validation Stage
       SDLValidationParameters:
         enable: true


### PR DESCRIPTION
This is https://github.com/dotnet/arcade/issues/3069 again, I recreated it because deleting the comment wasn't rendering properly so I made a new branch on my fork. 