### PR TITLE
Update docker image source

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,7 +41,7 @@ schedules:
 resources:
   containers:
   - container: LinuxContainer
-    image: microsoft/dotnet-buildtools-prereqs:ubuntu-14.04-cross-0cd4667-20170319080304
+    image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-14.04-cross-0cd4667-20170319080304
 
 stages:
 - stage: build


### PR DESCRIPTION
https://github.com/dotnet/dotnet-docker/issues/2848 - dockerhub images are now delisted.  This moves to mcr.microsoft.com version.