### PR TITLE
Revert "Use R&D pools (#2525)"

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,16 +8,16 @@ variables:
     - group: SDL_Settings
   - ${{ if eq(variables['System.TeamProject'], 'public') }}:
     - name: PoolProvider
-      value: NetCore1ESPool-Public
+      value: NetCorePublic-Pool
   - ${{ if ne(variables['System.TeamProject'], 'public') }}:
     - name: PoolProvider
-      value: NetCore1ESPool-Internal
+      value: NetCoreInternal-Pool
   - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule')) }}:
     - name: PoolProvider
-      value: NetCore1ESPool-Public-Int
+      value: NetCorePublic-Int-Pool
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule')) }}:
     - name: PoolProvider
-      value: NetCore1ESPool-Internal-Int
+      value: NetCoreInternal-Int-Pool
 
 trigger:
   batch: true
@@ -60,9 +60,9 @@ stages:
         pool:
           name: $(PoolProvider) # This is a queue-time parameter; Public default is NetCorePublic-Pool; Internal default is NetCoreInternal-Pool
           ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-            demands: ImageOverride -equals Build.Server.Amd64.VS2017.Open
+            queue: BuildPool.Server.Amd64.VS2017.Arcade.Open
           ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-            demands: ImageOverride -equals Build.Server.Amd64.VS2017
+            queue: BuildPool.Server.Amd64.VS2017.Arcade
         variables:
         - _InternalBuildArgs: ''
 
@@ -112,7 +112,7 @@ stages:
         pool:
           ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
             name: $(PoolProvider) # This is a queue-time parameter; Public default is NetCorePublic-Pool; Internal default is NetCoreInternal-Pool
-            demands: ImageOverride -equals Build.Ubuntu.1604.Amd64.Open
+            queue: BuildPool.Ubuntu.1604.Amd64.Arcade.Open
           ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
             name: Hosted Ubuntu 1604
         strategy:
@@ -181,7 +181,7 @@ stages:
         - job: Validate_Signing
           pool:
             name: $(PoolProvider) # This is a queue-time parameter; Public default is NetCorePublic-Pool; Internal default is NetCoreInternal-Pool
-            demands: ImageOverride -equals Build.Server.Amd64.VS2017
+            queue: BuildPool.Server.Amd64.VS2017.Arcade
           strategy:
             matrix:
               Test_Signing:


### PR DESCRIPTION
Staging CloudTest images have `-Int` suffix but we forgot to take it into account when migrating the pipeline. Also we need to increase max scale on staging pools. This PR temporarily reverts to the old pools to unblock the promotion.

Issue: https://github.com/dotnet/arcade/issues/7987