### PR TITLE
Migrate to 1ES pools

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,16 +8,16 @@ variables:
     - group: SDL_Settings
   - ${{ if eq(variables['System.TeamProject'], 'public') }}:
     - name: PoolProvider
-      value: NetCorePublic-Pool
+      value: NetCore1ESPool-Public
   - ${{ if ne(variables['System.TeamProject'], 'public') }}:
     - name: PoolProvider
-      value: NetCoreInternal-Pool
+      value: NetCore1ESPool-Internal
   - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule')) }}:
     - name: PoolProvider
-      value: NetCorePublic-Int-Pool
+      value: NetCore1ESPool-Public-Int
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule')) }}:
     - name: PoolProvider
-      value: NetCoreInternal-Int-Pool
+      value: NetCore1ESPool-Internal-Int
 
 trigger:
   batch: true
@@ -60,9 +60,9 @@ stages:
         pool:
           name: $(PoolProvider) # This is a queue-time parameter; Public default is NetCorePublic-Pool; Internal default is NetCoreInternal-Pool
           ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-            queue: BuildPool.Server.Amd64.VS2017.Arcade.Open
+            demands: ImageOverride -equals Build.Server.Amd64.VS2017.Open
           ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-            queue: BuildPool.Server.Amd64.VS2017.Arcade
+            demands: ImageOverride -equals Build.Server.Amd64.VS2017
         variables:
         - _InternalBuildArgs: ''
 
@@ -112,7 +112,7 @@ stages:
         pool:
           ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
             name: $(PoolProvider) # This is a queue-time parameter; Public default is NetCorePublic-Pool; Internal default is NetCoreInternal-Pool
-            queue: BuildPool.Ubuntu.1604.Amd64.Arcade.Open
+            demands: ImageOverride -equals Build.Ubuntu.1604.Amd64.Open
           ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
             name: Hosted Ubuntu 1604
         strategy:
@@ -181,7 +181,7 @@ stages:
         - job: Validate_Signing
           pool:
             name: $(PoolProvider) # This is a queue-time parameter; Public default is NetCorePublic-Pool; Internal default is NetCoreInternal-Pool
-            queue: BuildPool.Server.Amd64.VS2017.Arcade
+            demands: ImageOverride -equals Build.Server.Amd64.VS2017
           strategy:
             matrix:
               Test_Signing:


### PR DESCRIPTION
We have renamed staging 1ES images to match production names. Now we can once again apply the migration to 1ES  hosted pools.

Tracking issue: https://github.com/dotnet/arcade/issues/7987