### PR TITLE
[release/5.0] move to using ubuntu-latest for linux official build leg

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -113,7 +113,7 @@ stages:
             name: $(PoolProvider) # This is a queue-time parameter; Public default is NetCorePublic-Pool; Internal default is NetCoreInternal-Pool
             demands: ImageOverride -equals Build.Ubuntu.1604.Amd64.Open
           ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-            name: Hosted Ubuntu 1604
+            vmImage: ubuntu-latest
         strategy:
           matrix:
             Build_Debug:


### PR DESCRIPTION
release/5.0 PR for https://github.com/dotnet/arcade/issues/8066

Test build: https://dev.azure.com/dnceng/internal/_build/results?buildId=1430172&view=results