### PR TITLE
React to arcade template changes in setup-maestro-vars.yml

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -256,12 +256,10 @@ stages:
     - stage: Validate_Publishing
       displayName: Validate Publishing
       jobs:
-      - template: /eng/common/templates/post-build/setup-maestro-vars.yml
       - template: /eng/common/templates/job/job.yml
         parameters:
           name: Validate_Publishing
           displayName: Validate Publishing
-          dependsOn: setupMaestroVars
           timeoutInMinutes: 240
           pool:
             vmImage: windows-2019
@@ -273,6 +271,7 @@ stages:
             - name: skipComponentGovernanceDetection
               value: true
           steps:
+            - template: /eng/common/templates/post-build/setup-maestro-vars.yml
             - checkout: self
               clean: true
             - powershell: eng\validation\test-publishing.ps1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -115,7 +115,7 @@ stages:
             demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
           ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
             name: $(PoolProvider)
-          demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
+            demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
 
         strategy:
           matrix:
@@ -256,7 +256,7 @@ stages:
         -TsaRepositoryName "Arcade-Validation"
         -TsaCodebaseName "Arcade-Validation"
         -TsaPublish $True'
-  - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
+  - ${{ if ne(variables['Build.SourceBranch'], 'refs/heads/main') }}:
     - stage: Validate_Publishing
       displayName: Validate Publishing
       jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -114,7 +114,9 @@ stages:
             name: $(PoolProvider)  # This is a queue-time parameter; Public default is NetCore1ESPool-Public; Internal default is NetCore1ESPool-Internal
             demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
           ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-            vmImage: ubuntu-latest
+            name: $(PoolProvider)
+          demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
+
         strategy:
           matrix:
             Build_Debug:
@@ -144,7 +146,8 @@ stages:
 
       - job: Validate_Helix
         pool:
-          vmImage: windows-2019
+          name: $(PoolProvider)
+          demands: ImageOverride -equals build.windows.10.amd64.vs2019
         variables:
         - HelixApiAccessToken: ''
         - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
@@ -219,7 +222,8 @@ stages:
         name: Create_BAR_ID_Tag
         displayName: Create BAR ID Tag
         pool: 
-          vmImage: windows-2019
+          name: $(PoolProvider)
+          demands: ImageOverride -equals build.windows.10.amd64.vs2019
         variables:
           - group: Publish-Build-Assets
           - group: DotNetBot-GitHub
@@ -262,7 +266,8 @@ stages:
           displayName: Validate Publishing
           timeoutInMinutes: 240
           pool:
-            vmImage: windows-2019
+            name: $(PoolProvider)
+            demands: ImageOverride -equals build.windows.10.amd64.vs2019
           variables:
             - group: Publish-Build-Assets
             - group: DotNetBot-GitHub
@@ -291,7 +296,8 @@ stages:
         parameters:
           name: Promote_Arcade_To_Latest
           pool:
-            vmImage: windows-2019
+            name: $(PoolProvider)
+            demands: ImageOverride -equals build.windows.10.amd64.vs2019
           displayName: Promote Arcade to '.NET Eng - Latest' channel
           timeoutInMinutes: 180
           variables:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -256,7 +256,7 @@ stages:
         -TsaRepositoryName "Arcade-Validation"
         -TsaCodebaseName "Arcade-Validation"
         -TsaPublish $True'
-  - ${{ if ne(variables['Build.SourceBranch'], 'refs/heads/main') }}:
+  - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
     - stage: Validate_Publishing
       displayName: Validate Publishing
       jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -146,8 +146,12 @@ stages:
 
       - job: Validate_Helix
         pool:
-          name: $(PoolProvider)
-          demands: ImageOverride -equals build.windows.10.amd64.vs2019
+          ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+            name: $(PoolProvider) 
+            demands: ImageOverride -equals Build.Server.Amd64.VS2019.Open
+          ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+            name: $(PoolProvider)
+            demands: ImageOverride -equals Build.Server.Amd64.VS2019
         variables:
         - HelixApiAccessToken: ''
         - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:


### PR DESCRIPTION
https://github.com/dotnet/arcade/issues/8368

This used to be a job template. It's now a steps template. Since it runs in the same job, we no longer need the `dependsOn`. 

Validated this works as expected in this test build: https://dev.azure.com/dnceng/internal/_build/results?buildId=1563053&view=results