### PR TITLE
Add tag for Validating AzDO build

### DIFF
--- a/eng/create-baridtag.ps1
+++ b/eng/create-baridtag.ps1
@@ -14,7 +14,9 @@ $arcadeSdkPackageName = 'Microsoft.DotNet.Arcade.Sdk'
 $arcadeSdkVersion = $GlobalJson.'msbuild-sdks'.$arcadeSdkPackageName
 $assetData = & $darc get-asset --name $arcadeSdkPackageName --version $arcadeSdkVersion --github-pat $githubPAT --azdev-pat $azdoToken --password $bartoken --output-format json | convertFrom-Json
 
-## Get the BAR Build ID for the version of Arcade we are validating
+# Get the BAR Build ID for the version of Arcade we are validating
 $barBuildId = $assetData.build.id
+$azdoBuildUrl = $assetData.build.buildLink
 
 Write-Host "##vso[build.addbuildtag]ValidatingBarIds $barBuildId"
+Write-Host "##vso[build.addbuildtag]ValidatingAzDOBuild $azdoBuildUrl"

--- a/eng/create-baridtag.ps1
+++ b/eng/create-baridtag.ps1
@@ -16,7 +16,7 @@ $assetData = & $darc get-asset --name $arcadeSdkPackageName --version $arcadeSdk
 
 # Get the BAR Build ID for the version of Arcade we are validating
 $barBuildId = $assetData.build.id
-$azdoBuildUrl = $assetData.build.buildLink
+$azdoBuildId = ($assetData.build.buildLink -split "=")[-1]
 
 Write-Host "##vso[build.addbuildtag]ValidatingBarIds $barBuildId"
-Write-Host "##vso[build.addbuildtag]ValidatingAzDOBuild $azdoBuildUrl"
+Write-Host "##vso[build.addbuildtag]ValidatingAzDOBuild $azdoBuildId"

--- a/eng/create-baridtag.ps1
+++ b/eng/create-baridtag.ps1
@@ -16,7 +16,7 @@ $assetData = & $darc get-asset --name $arcadeSdkPackageName --version $arcadeSdk
 
 # Get the BAR Build ID for the version of Arcade we are validating
 $barBuildId = $assetData.build.id
-$azdoBuildId = ($assetData.build.buildLink -split "=")[-1]
+$azdoBuildId = $assetData.build.azdoBuildId
 
 Write-Host "##vso[build.addbuildtag]ValidatingBarIds $barBuildId"
 Write-Host "##vso[build.addbuildtag]ValidatingAzDOBuild $azdoBuildId"


### PR DESCRIPTION
Using the bar id itself means that we end up having to directly reference maestro to get all of the comparison builds (we have to go current build -> maestro -> azdo build for that bar id -> compare build -> maestro -> azdo build). Maestro can be clunky and if we can avoid using it, that's better. Since we can just get the azdo url for a given asset/build, we can avoid the code that uses this information needing maestro by just saving the build url