### PR TITLE
Move from impendingly-removed Debian 9 queue to a dockerized Debian 10

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -173,12 +173,12 @@ stages:
             EnableXUnitReporter: true
             WaitForWorkItemCompletion: true
             ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-              HelixTargetQueues: Windows.10.Amd64.Open;Debian.9.Amd64.Open
+              HelixTargetQueues: Windows.10.Amd64.Open;(Debian.10.Amd64.Open)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-10-helix-amd64-20220511124228-fbf2f29
               HelixSource: pr/dotnet/arcade-validation/$(Build.SourceBranch)
               IsExternal: true
               Creator: arcade-validation
             ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-              HelixTargetQueues: Windows.10.Amd64;Debian.9.Amd64
+              HelixTargetQueues: Windows.10.Amd64;(Debian.10.Amd64)Ubuntu.2004.Amd64@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-10-helix-amd64-20220511124228-fbf2f29
               HelixSource: official/dotnet/arcade-validation/$(Build.SourceBranch)
               HelixAccessToken: $(HelixApiAccessToken)
         displayName: Validate Helix


### PR DESCRIPTION
Official internal run version: https://dev.azure.com/dnceng/internal/_build/results?buildId=1834538&view=results