### PR TITLE
Small test fix

### DIFF
--- a/src/Validation/tests/RepoTests.cs
+++ b/src/Validation/tests/RepoTests.cs
@@ -427,8 +427,8 @@ namespace Validation.Tests
             // artifacts/log/**/AssetManifests/*. There should only be one.
             string logsDirectory = Path.Combine(builder.TestRepoRoot, "artifacts", "log");
             string[] logFiles = Directory.GetFiles(logsDirectory, "*.xml", SearchOption.AllDirectories);
-            string escapedDirSeperator = Regex.Escape($"{Path.DirectorySeparatorChar}");
-            Regex assetManifestRegex = new Regex(@$".*{escapedDirSeperator}AssetManifest{escapedDirSeperator}.*\.xml");
+            string escapedDirSeparator = Regex.Escape($"{Path.DirectorySeparatorChar}");
+            Regex assetManifestRegex = new Regex(@$".*{escapedDirSeparator}AssetManifest{escapedDirSeparator}.*\.xml");
             var assetManifests = logFiles.Where(am => assetManifestRegex.IsMatch(am)).ToArray();
             assetManifests.Length.Should().Be(1);
             string assetManifestText = File.ReadAllText(assetManifests[0]);

--- a/src/Validation/tests/TestRepoBuilder.cs
+++ b/src/Validation/tests/TestRepoBuilder.cs
@@ -50,23 +50,20 @@ namespace Validation.Tests
 
         public static void KillSpecificExecutable(string fileName)
         {
-            try
-            {
-                System.Diagnostics.Process[] processes = System.Diagnostics.Process.GetProcesses();
+            string justProcessName = Path.GetFileNameWithoutExtension(Path.GetFileName(fileName));
+            System.Diagnostics.Process[] processes = System.Diagnostics.Process.GetProcessesByName(justProcessName);
 
-                foreach (var process in processes)
+            foreach (var process in processes)
+            {
+                try
                 {
-                    try
+                    if (process.MainModule.FileName == fileName)
                     {
-                        if (process.MainModule.FileName == fileName)
-                        {
-                            process.Kill(true);
-                        }
+                        process.Kill(true);
                     }
-                    catch { }
                 }
+                catch { } // Ignored
             }
-            catch { }
         }
 
         public static string DotNetHostExecutableName


### PR DESCRIPTION
If the killing processes logic hit an exception it may not enumerate all processes on the machine, leaving leaked dotnet.exe for the subsequent cleanup step