### PR TITLE
[Release/6.0] Move to new images that have .net 6 installed 

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,9 +62,9 @@ stages:
         pool:
           name: $(PoolProvider) # This is a queue-time parameter; Public default is NetCorePublic-Pool; Internal default is NetCoreInternal-Pool
           ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-            demands: ImageOverride -equals Build.Server.Amd64.VS2017.Open
+            demands: ImageOverride windows.vs2019.amd64.open
           ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-            demands: ImageOverride -equals Build.Server.Amd64.VS2017
+            demands: ImageOverride -equals windows.vs2019.amd64
         variables:
         - _InternalBuildArgs: ''
 
@@ -150,10 +150,10 @@ stages:
         pool:
           ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
             name: $(PoolProvider) 
-            demands: ImageOverride -equals Build.Server.Amd64.VS2019.Open
+            demands: ImageOverride -equals windows.vs2019.amd64.Open
           ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
             name: $(PoolProvider)
-            demands: ImageOverride -equals Build.Server.Amd64.VS2019
+            demands: ImageOverride -equals windows.vs2019.amd64
         variables:
         - HelixApiAccessToken: ''
         - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
@@ -190,7 +190,7 @@ stages:
         - job: Validate_Signing
           pool:
             name: $(PoolProvider) # This is a queue-time parameter; Public default is NetCorePublic-Pool; Internal default is NetCoreInternal-Pool
-            demands: ImageOverride -equals Build.Server.Amd64.VS2017
+            demands: ImageOverride -equals windows.vs2019.amd64
           strategy:
             matrix:
               Test_Signing:
@@ -250,7 +250,7 @@ stages:
           timeoutInMinutes: 240
           pool:
             name: $(PoolProvider)
-            demands: ImageOverride -equals build.windows.10.amd64.vs2019
+            demands: ImageOverride -equals windows.vs2019.amd64
           variables:
             - group: Publish-Build-Assets
             - group: DotNetBot-GitHub
@@ -280,7 +280,7 @@ stages:
           name: Promote_to_net6_eng_channel
           pool:
             name: $(PoolProvider)
-            demands: ImageOverride -equals build.windows.10.amd64.vs2019
+            demands: ImageOverride -equals windows.vs2019.amd64
           displayName: Promote Arcade to '.NET 6 Eng' channel
           timeoutInMinutes: 180
           variables:


### PR DESCRIPTION
Move the build to use the new images. These images have .net 6 installed, which is required for the validate publishing leg to run successfully.

Fixes the official build break in https://github.com/dotnet/arcade/issues/10769

I have a test build of these changes here: https://dev.azure.com/dnceng/internal/_build/results?buildId=1986870&view=results
