### PR TITLE
[Release/5.0] stop using hosted pool (with expired image) for validate publishing leg

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -243,7 +243,8 @@ stages:
           dependsOn: setupMaestroVars
           timeoutInMinutes: 240
           pool: 
-            vmImage: vs2017-win2016
+            name: $(PoolProvider) # This is a queue-time parameter; Public default is NetCorePublic-Pool; Internal default is NetCoreInternal-Pool
+            demands: ImageOverride -equals Build.Server.Amd64.VS2017
           variables:
             - group: Publish-Build-Assets
             - group: DotNetBot-GitHub

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,9 +61,9 @@ stages:
         pool:
           name: $(PoolProvider) # This is a queue-time parameter; Public default is NetCorePublic-Pool; Internal default is NetCoreInternal-Pool
           ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-            demands: ImageOverride -equals Build.Server.Amd64.VS2017.Open
+            demands: ImageOverride -equals windows.vs2019.amd64.Open
           ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-            demands: ImageOverride -equals Build.Server.Amd64.VS2017
+            demands: ImageOverride -equals windows.vs2019.amd64
         variables:
         - _InternalBuildArgs: ''
 
@@ -143,9 +143,9 @@ stages:
         pool:
           name: $(PoolProvider) # This is a queue-time parameter; Public default is NetCorePublic-Pool; Internal default is NetCoreInternal-Pool
           ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-            demands: ImageOverride -equals Build.Server.Amd64.VS2017.Open
+            demands: ImageOverride -equals windows.vs2019.amd64.Open
           ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-            demands: ImageOverride -equals Build.Server.Amd64.VS2017
+            demands: ImageOverride -equals windows.vs2019.amd64
         variables:
         - HelixApiAccessToken: ''
         - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
@@ -180,7 +180,7 @@ stages:
         - job: Validate_Signing
           pool: 
             name: $(PoolProvider) # This is a queue-time parameter; Public default is NetCorePublic-Pool; Internal default is NetCoreInternal-Pool
-            demands: ImageOverride -equals Build.Server.Amd64.VS2017
+            demands: ImageOverride -equals windows.vs2019.amd64
           strategy:
             matrix:
               Test_Signing:
@@ -244,7 +244,7 @@ stages:
           timeoutInMinutes: 240
           pool: 
             name: $(PoolProvider) # This is a queue-time parameter; Public default is NetCorePublic-Pool; Internal default is NetCoreInternal-Pool
-            demands: ImageOverride -equals Build.Server.Amd64.VS2017
+            demands: ImageOverride -equals windows.2017.amd64
           variables:
             - group: Publish-Build-Assets
             - group: DotNetBot-GitHub

--- a/eng/validation/get-darc.ps1
+++ b/eng/validation/get-darc.ps1
@@ -1,5 +1,5 @@
 $path = "$PSScriptRoot\darc\$(New-Guid)"
 
-& $PSScriptRoot\..\common\darc-init.ps1 -toolpath $path | Out-Host
+& $PSScriptRoot\..\common\darc-init.ps1 -toolpath $path -darcVersion "1.1.0-beta.22220.1" | Out-Host
 
 return "$path\darc.exe"

--- a/eng/validation/update-channel.ps1
+++ b/eng/validation/update-channel.ps1
@@ -21,7 +21,7 @@ $headers = Get-Headers 'text/plain' $barToken
 
 try {
     # Get the Microsoft.DotNet.Arcade.Sdk with the version $arcadeSdkVersion so we can get the id of the build
-    $assets = Invoke-WebRequest -Uri $getAssetsApiEndpoint -Headers $headers | ConvertFrom-Json
+    $assets = Invoke-WebRequest -Uri $getAssetsApiEndpoint -Headers $headers -UseBasicParsing | ConvertFrom-Json
 
     if (!$assets) {
         Write-Host "Asset '$arcadeSdkPackageName' with version $arcadeSdkVersion was not found"


### PR DESCRIPTION
Several fixes for the official build of arcade-validation:

* stop using Build.* images, and move to the windows.2019 image
* add UseBasicParsing switch for invokeWebRequest calls
* Stop using hosted pool for validate publishing leg
* use netcoreapp3.1 darc so that we can install it

This is still to unblock flow of this branch and hopefully this is the last battle against this branch.