### PR TITLE
Create a tool manifest

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,5 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {}
+}

--- a/.gitignore
+++ b/.gitignore
@@ -332,3 +332,6 @@ ASALocalRun/
 
 # MFractors (Xamarin productivity tool) working folder
 .mfractor/
+
+# Ignore dotnet tool manifest changes; keep dotnet-tools.json empty.
+.config/


### PR DESCRIPTION
- see dotnet/dnceng#573
- trim-assets-version.ps1 is the only place we use `dotnet tool install --local`
  - w/o a tool manifest `--local` consistently fails
- this is a reaction to dotnet/arcade@a4c7aafc998e / dotnet/arcade#13979