### PR TITLE
[release/6.0] Bump MSBuild.ProjectCreation to 10.0.0

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,11 +3,8 @@
   <PropertyGroup>
     <VersionPrefix>1.0.0</VersionPrefix>
     <PreReleaseVersionLabel>prerelease</PreReleaseVersionLabel>
-    <NuGetVersion>6.4.2</NuGetVersion>
-    <NewtonsoftJsonVersion>13.0.3</NewtonsoftJsonVersion>
-    <MicrosoftBuildVersion>16.11.0</MicrosoftBuildVersion>
-    <MSBuildProjectCreationVersion>1.4.6</MSBuildProjectCreationVersion>
     <FluentAssertionsVersion>5.10.3</FluentAssertionsVersion>
-    <SystemDrawingCommonVersion>4.7.2</SystemDrawingCommonVersion>
+    <MicrosoftBuildVersion>17.3.2</MicrosoftBuildVersion>
+    <MSBuildProjectCreationVersion>10.0.0</MSBuildProjectCreationVersion>
   </PropertyGroup>
 </Project>

--- a/src/Validation/tests/Validation.Tests.csproj
+++ b/src/Validation/tests/Validation.Tests.csproj
@@ -8,12 +8,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildVersion)" />
     <PackageReference Include="MSBuild.ProjectCreation" Version="$(MSBuildProjectCreationVersion)" />
-    <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonVersion)" />
-    <PackageReference Include="Nuget.Protocol" Version="$(NugetVersion)" />
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />    
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- see https://github.com/dotnet/dnceng/issues/566
- latest version of the package remains `net6.0`-compatible
- also bump Microsoft.Build to 17.3.2, latest `net6.0` package
- remove unnecessary package references
  - transitive references seem sufficient at this time