### PR TITLE
Updating hardcoded MSbuild version

### DIFF
--- a/eng/common/sdk-task.ps1
+++ b/eng/common/sdk-task.ps1
@@ -64,7 +64,7 @@ try {
       $GlobalJson.tools | Add-Member -Name "vs" -Value (ConvertFrom-Json "{ `"version`": `"16.5`" }") -MemberType NoteProperty
     }
     if( -not ($GlobalJson.tools.PSObject.Properties.Name -match "xcopy-msbuild" )) {
-      $GlobalJson.tools | Add-Member -Name "xcopy-msbuild" -Value "17.6.0-2" -MemberType NoteProperty
+      $GlobalJson.tools | Add-Member -Name "xcopy-msbuild" -Value "17.7.2" -MemberType NoteProperty
     }
     if ($GlobalJson.tools."xcopy-msbuild".Trim() -ine "none") {
         $xcopyMSBuildToolsFolder = InitializeXCopyMSBuild $GlobalJson.tools."xcopy-msbuild" -install $true

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -385,7 +385,7 @@ function InitializeVisualStudioMSBuild([bool]$install, [object]$vsRequirements =
   # If the version of msbuild is going to be xcopied,
   # use this version. Version matches a package here:
   # https://dev.azure.com/dnceng/public/_artifacts/feed/dotnet-eng/NuGet/RoslynTools.MSBuild/versions/17.6.0-2
-  $defaultXCopyMSBuildVersion = '17.7.0'
+  $defaultXCopyMSBuildVersion = '17.7.2'
 
   if (!$vsRequirements) {
     if (Get-Member -InputObject $GlobalJson.tools -Name 'vs') {

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -385,7 +385,7 @@ function InitializeVisualStudioMSBuild([bool]$install, [object]$vsRequirements =
   # If the version of msbuild is going to be xcopied,
   # use this version. Version matches a package here:
   # https://dev.azure.com/dnceng/public/_artifacts/feed/dotnet-eng/NuGet/RoslynTools.MSBuild/versions/17.6.0-2
-  $defaultXCopyMSBuildVersion = '17.6.0-2'
+  $defaultXCopyMSBuildVersion = '17.7.0'
 
   if (!$vsRequirements) {
     if (Get-Member -InputObject $GlobalJson.tools -Name 'vs') {


### PR DESCRIPTION
Arcade validation pipeline is failing cos of the hard coded MS build version

Failing build-> https://dev.azure.com/dnceng/internal/_build/results?buildId=2275564&view=logs&j=b11b921d-8982-5bb3-754b-b114d42fd804&t=fb192a8b-e433-5fc8-e2b0-276ab015e7d5

Test -> https://dev.azure.com/dnceng/internal/_build/results?buildId=2276170&view=logs&s=3df7d716-4c9c-5c26-9f45-11f62216640d&j=b11b921d-8982-5bb3-754b-b114d42fd804