### PR TITLE
Fix release branch trigger in azure-pipelines.yml

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,7 +24,7 @@ trigger:
   branches:
     include:
       - main
-      - release/3.x
+      - release/*
 pr:
   branches:
     include:


### PR DESCRIPTION
Noticed this was still using release/3.x in main, we should just trigger on all release branches.

/cc @riarenas 