### PR TITLE
Specify source channel for asset validation

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -231,14 +231,11 @@ stages:
           demands: ImageOverride -equals windows.vs2022.amd64
         variables:
           - group: Publish-Build-Assets
-          - group: DotNetBot-GitHub
         steps:
           - checkout: self
             clean: true
           - powershell: eng/create-baridtag.ps1
-              -azdoToken $(dn-bot-dotnet-build-rw-code-rw)
               -barToken $(MaestroAccessToken)
-              -githubPAT $(BotAccount-dotnet-bot-repo-PAT)
             displayName: Create BAR ID Tag
             name: Create_BAR_ID_Tag
   - template: eng\common\templates\post-build\post-build.yml

--- a/eng/create-baridtag.ps1
+++ b/eng/create-baridtag.ps1
@@ -1,7 +1,5 @@
 Param(
-  [Parameter(Mandatory=$true)][string] $azdoToken,
   [Parameter(Mandatory=$true)][string] $barToken,
-  [Parameter(Mandatory=$true)][string] $githubPAT,
   [string] $sourceChannelName = '.NET Eng - Validation'
 )
 
@@ -13,7 +11,7 @@ $darc = & "$PSScriptRoot\validation\get-darc.ps1"
 
 $arcadeSdkPackageName = 'Microsoft.DotNet.Arcade.Sdk'
 $arcadeSdkVersion = $GlobalJson.'msbuild-sdks'.$arcadeSdkPackageName
-$assetData = & $darc get-asset --name $arcadeSdkPackageName --version $arcadeSdkVersion --channel "$sourceChannelName" --github-pat $githubPAT --azdev-pat $azdoToken --password $bartoken --output-format json | convertFrom-Json
+$assetData = & $darc get-asset --name $arcadeSdkPackageName --version $arcadeSdkVersion --channel "$sourceChannelName" --password $bartoken --output-format json | convertFrom-Json
 
 # Get the BAR Build ID for the version of Arcade we are validating
 $barBuildId = $assetData.build.id

--- a/eng/create-baridtag.ps1
+++ b/eng/create-baridtag.ps1
@@ -1,7 +1,8 @@
 Param(
   [Parameter(Mandatory=$true)][string] $azdoToken,
   [Parameter(Mandatory=$true)][string] $barToken,
-  [Parameter(Mandatory=$true)][string] $githubPAT
+  [Parameter(Mandatory=$true)][string] $githubPAT,
+  [string] $sourceChannelName = '.NET Eng - Validation'
 )
 
 set-strictmode -version 2.0
@@ -12,7 +13,7 @@ $darc = & "$PSScriptRoot\validation\get-darc.ps1"
 
 $arcadeSdkPackageName = 'Microsoft.DotNet.Arcade.Sdk'
 $arcadeSdkVersion = $GlobalJson.'msbuild-sdks'.$arcadeSdkPackageName
-$assetData = & $darc get-asset --name $arcadeSdkPackageName --version $arcadeSdkVersion --github-pat $githubPAT --azdev-pat $azdoToken --password $bartoken --output-format json | convertFrom-Json
+$assetData = & $darc get-asset --name $arcadeSdkPackageName --version $arcadeSdkVersion --channel "$sourceChannelName" --github-pat $githubPAT --azdev-pat $azdoToken --password $bartoken --output-format json | convertFrom-Json
 
 # Get the BAR Build ID for the version of Arcade we are validating
 $barBuildId = $assetData.build.id

--- a/eng/validation/build-arcadewithrepo.ps1
+++ b/eng/validation/build-arcadewithrepo.ps1
@@ -11,7 +11,8 @@ Param(
   [string] $buildParameters = '',
   [switch] $pushBranchToGithub,
   [string] $azdoRepoName,
-  [string] $subscribedBranchName
+  [string] $subscribedBranchName,
+  [string] $sourceChannelName = '.NET Eng - Validation'
 )
 
 set-strictmode -version 2.0
@@ -198,7 +199,7 @@ if($null -ne $branchExists)
 Git-Command $global:githubRepoName checkout -b $global:targetBranch $sha
 
 ## Get the BAR Build ID for the version of Arcade we want to use in update-dependecies
-$asset = & $darc get-asset --name $global:arcadeSdkPackageName --version $global:arcadeSdkVersion --github-pat $global:githubPAT --azdev-pat $global:azdoToken --password $global:bartoken
+$asset = & $darc get-asset --name $global:arcadeSdkPackageName --version $global:arcadeSdkVersion --channel "$sourceChannelName" --github-pat $global:githubPAT --azdev-pat $global:azdoToken --password $global:bartoken
 $barBuildIdString = $asset | Select-String -Pattern 'BAR Build Id:'
 $barBuildId = ([regex]"\d+").Match($barBuildIdString).Value
 

--- a/eng/validation/test-publishing.ps1
+++ b/eng/validation/test-publishing.ps1
@@ -16,6 +16,7 @@ $ErrorActionPreference = 'Stop'
 $darc = & "$PSScriptRoot\get-darc.ps1"
 
 $global:buildId = $buildId
+$global:sourceChannel = ".NET Eng - Validation"
 $global:targetChannel = "General Testing"
 $global:azdoToken = $azdoToken
 $global:azdoUser = $azdoUser
@@ -45,7 +46,7 @@ $global:arcadeSdkPackageName = 'Microsoft.DotNet.Arcade.Sdk'
 $global:arcadeSdkVersion = $GlobalJson.'msbuild-sdks'.$global:arcadeSdkPackageName
 $global:azdoRepoName = "dotnet-arcade"
 $global:azdoRepoUri = "https://unused:$azdoToken@${global:azdoOrg}.visualstudio.com/${global:azdoProject}/_git/${global:azdoRepoName}"
-$jsonAsset = & $darc get-asset --name $global:arcadeSdkPackageName --version $global:arcadeSdkVersion --github-pat $global:githubPAT --azdev-pat $global:azdoToken --password $global:bartoken --output-format json | convertFrom-Json
+$jsonAsset = & $darc get-asset --name $global:arcadeSdkPackageName --version $global:arcadeSdkVersion --channel "$sourceChannel" --github-pat $global:githubPAT --azdev-pat $global:azdoToken --password $global:bartoken --output-format json | convertFrom-Json
 $sha = $jsonAsset.build.commit
 $global:targetBranch = "val/arcade-" + $global:arcadeSdkVersion
 


### PR DESCRIPTION
Resolves dotnet/dnceng#1964.

The validation checks get confused if an asset with the same name and version is published more than once. This is rare, but can happen. This change adds the source-channel flag where appropriate for calls to `darc`.