### PR TITLE
Update windows 10 testing target

### DIFF
--- a/azure-pipelines-pr.yml
+++ b/azure-pipelines-pr.yml
@@ -103,7 +103,7 @@ stages:
             DotNetCliVersion: 9.0.100-preview.1.24101.2
             EnableXUnitReporter: true
             WaitForWorkItemCompletion: true
-            HelixTargetQueues: Windows.10.Amd64.Open;(Debian.12.Amd64.Open)Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-12-helix-amd64
+            HelixTargetQueues: windows.amd64.server2022.open;(Debian.12.Amd64.Open)Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-12-helix-amd64
             HelixSource: pr/dotnet/arcade-validation/$(Build.SourceBranch)
             IsExternal: true
             Creator: arcade-validation

--- a/azure-pipelines-pr.yml
+++ b/azure-pipelines-pr.yml
@@ -103,7 +103,7 @@ stages:
             DotNetCliVersion: 9.0.100-preview.1.24101.2
             EnableXUnitReporter: true
             WaitForWorkItemCompletion: true
-            HelixTargetQueues: windows.amd64.server2022.open;(Debian.12.Amd64.Open)Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-12-helix-amd64
+            HelixTargetQueues: Windows.Amd64.Server2022.Open;(Debian.12.Amd64.Open)Ubuntu.2204.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-12-helix-amd64
             HelixSource: pr/dotnet/arcade-validation/$(Build.SourceBranch)
             IsExternal: true
             Creator: arcade-validation

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -146,7 +146,7 @@ extends:
                 DotNetCliVersion: 9.0.100-preview.1.24101.2
                 EnableXUnitReporter: true
                 WaitForWorkItemCompletion: true
-                HelixTargetQueues: windows.amd64.server2022;(Debian.12.Amd64)Ubuntu.2204.Amd64@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-12-helix-amd64
+                HelixTargetQueues: Windows.Amd64.Server2022;(Debian.12.Amd64)Ubuntu.2204.Amd64@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-12-helix-amd64
                 HelixSource: official/dotnet/arcade-validation/$(Build.SourceBranch)
                 HelixAccessToken: $(HelixApiAccessToken)
             displayName: Validate Helix

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -146,7 +146,7 @@ extends:
                 DotNetCliVersion: 9.0.100-preview.1.24101.2
                 EnableXUnitReporter: true
                 WaitForWorkItemCompletion: true
-                HelixTargetQueues: Windows.10.Amd64;(Debian.12.Amd64)Ubuntu.2204.Amd64@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-12-helix-amd64
+                HelixTargetQueues: windows.amd64.server2022;(Debian.12.Amd64)Ubuntu.2204.Amd64@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-12-helix-amd64
                 HelixSource: official/dotnet/arcade-validation/$(Build.SourceBranch)
                 HelixAccessToken: $(HelixApiAccessToken)
             displayName: Validate Helix


### PR DESCRIPTION
https://github.com/dotnet/arcade/issues/14622

Update our windows testing target which previously targeted 2016-datacenter to our 2022-datacenter queue.