### PR TITLE
fix validation channel name for bar id tagging

### DIFF
--- a/eng/create-baridtag.ps1
+++ b/eng/create-baridtag.ps1
@@ -1,6 +1,6 @@
 Param(
   [Parameter(Mandatory=$true)][string] $barToken,
-  [string] $sourceChannelName = '.NET 9 Eng'
+  [string] $sourceChannelName = '.NET 9 Eng - Validation'
 )
 
 set-strictmode -version 2.0


### PR DESCRIPTION
Fixes official build failures. The script can't (rightfully) find the builds it's trying to validate as it's trying to use the wrong channel 

https://dev.azure.com/dnceng/internal/_build/results?buildId=2526924&view=logs&j=53ba88cb-b0cf-52fc-0bd4-89a0e9972164&t=39268a59-48a4-5735-6fe3-9378ea4b48e1