### PR TITLE
Enable dry-run signing in Linux PR Validation

### DIFF
--- a/azure-pipelines-pr.yml
+++ b/azure-pipelines-pr.yml
@@ -77,6 +77,7 @@ stages:
         - script: eng/common/cibuild.sh
             --configuration $(_BuildConfig)
             --prepareMachine
+            --sign
           displayName: Unix Build / Publish
         - task: ComponentGovernanceComponentDetection@0
           displayName: Component Governance scan


### PR DESCRIPTION
Related to https://github.com/dotnet/arcade/issues/14430 and https://github.com/dotnet/arcade/issues/14431

Validates the changes from https://github.com/dotnet/arcade/pull/15045

Enables dry run signing in Linux PR validation runs.