### PR TITLE
Enable signing on Linux

### DIFF
--- a/azure-pipelines-pr.yml
+++ b/azure-pipelines-pr.yml
@@ -67,10 +67,10 @@ stages:
           matrix:
             Build_Debug:
               _BuildConfig: Debug
-              _SignType: none
+              _SignType: none # Test signing is not supported on Linux and macOS.
             Build_Release:
               _BuildConfig: Release
-              _SignType: none
+              _SignType: none # Test signing is not supported on Linux and macOS.
         steps:
         - checkout: self
           clean: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,6 +54,7 @@ extends:
       - template: /eng/common/templates-official/jobs/jobs.yml@self
         parameters:
           enableMicrobuild: true
+          enableMicrobuildForMacAndLinux: true
           enablePublishBuildArtifacts: true
           enablePublishBuildAssets: true
           enablePublishUsingPipelines: ${{ variables._PublishUsingPipelines }}
@@ -100,14 +101,18 @@ extends:
               image: 1es-ubuntu-2204
               os: linux
 
+            variables:
+            - _InternalBuildArgs: /p:DotNetSignType=$(_SignType)
+                /p:TeamName=$(_TeamName)
+                /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
+                /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+
             strategy:
               matrix:
-                Build_Debug:
-                  _BuildConfig: Debug
-                  _SignType: none
+                # No test signing - it's not supported on Linux and macOS
                 Build_Release:
                   _BuildConfig: Release
-                  _SignType: none
+                  _SignType: real
             steps:
             - checkout: self
               clean: true
@@ -119,9 +124,12 @@ extends:
               condition: ne(variables['Agent.OS'], 'Windows_NT')
               env:
                 Token: $(dn-bot-dnceng-artifact-feeds-rw)
+            # Remove --sign from the script command with https://github.com/dotnet/source-build/issues/4064
             - script: eng/common/cibuild.sh
                 --configuration $(_BuildConfig)
                 --prepareMachine
+                --sign
+                $(_InternalBuildArgs)
               displayName: Unix Build / Publish
             - task: ComponentGovernanceComponentDetection@0
               displayName: Component Governance scan
@@ -151,7 +159,7 @@ extends:
                 HelixAccessToken: $(HelixApiAccessToken)
             displayName: Validate Helix
 
-          - job: Validate_Signing
+          - job: Validate_Signing_Windows
             strategy:
               matrix:
                 Test_Signing:
@@ -177,7 +185,40 @@ extends:
                   /p:DotNetSignType=$(_SignType)
                   /p:TeamName=DotNetCore
                   /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
-            displayName: Sign packages
+
+          - job: Validate_Signing_Linux
+            container: LinuxContainer
+            pool:
+              name: $(PoolProvider)
+              image: 1es-ubuntu-2204
+              os: linux
+
+            variables:
+            - _InternalBuildArgs: /p:DotNetSignType=$(_SignType)
+                /p:TeamName=$(_TeamName)
+                /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+
+            strategy:
+              matrix:
+                # No test signing - it's not supported on Linux and macOS
+                Real_Signing:
+                  _BuildConfig: Release
+                  _SignType: real
+            steps:
+              - checkout: self
+                clean: true
+              - task: CopyFiles@2
+                displayName: Copy test packages to artifacts directory
+                inputs:
+                  sourceFolder: $(Build.SourcesDirectory)/src/Validation/Resources
+                  targetFolder: $(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)/NonShipping
+              - script: eng/common/build.sh
+                  --configuration $(_BuildConfig)
+                  --restore
+                  --prepareMachine
+                  --sign
+                  --ci
+                  $(_InternalBuildArgs)
 
     - stage: Create_BAR_ID_Tag
       displayName: Create BAR ID Tag

--- a/src/Validation/src/Validation.csproj
+++ b/src/Validation/src/Validation.csproj
@@ -8,11 +8,7 @@
 
   <!-- Set package ID for official signed builds. Needed to publish both Windows and Linux signed packages to build asset registry. -->
   <PropertyGroup Condition="'$(DotNetSignType)' == 'real'">
-    <BuildRid Condition="'$(BuildRid)' == '' and '$(MSBuildRuntimeType)' == 'core'">$([System.Runtime.InteropServices.RuntimeInformation]::RuntimeIdentifier)</BuildRid>
-    <TargetArchitecture Condition="'$(TargetArchitecture)' == ''">$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant)</TargetArchitecture>
-    <TargetOS Condition="'$(TargetOS)' == ''">$(BuildRid.Substring(0, $(BuildRid.LastIndexOf('-'))))</TargetOS>
-    <TargetRid Condition="'$(TargetRid)' == ''">$(TargetOS)-$(TargetArchitecture)</TargetRid>
-    <PackageId>Validation.$(TargetRid)</PackageId>
+    <PackageId>Validation.$(OS)</PackageId>
   </PropertyGroup>
   
 </Project>

--- a/src/Validation/src/Validation.csproj
+++ b/src/Validation/src/Validation.csproj
@@ -4,7 +4,6 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>$(NetCurrent)</TargetFrameworks>
     <IsPackable>true</IsPackable>
-    <SignAssembly>true</SignAssembly>
   </PropertyGroup>
 
   <!-- Set package ID for official signed builds. Needed to publish both Windows and Linux signed packages to build asset registry. -->

--- a/src/Validation/src/Validation.csproj
+++ b/src/Validation/src/Validation.csproj
@@ -6,5 +6,14 @@
     <IsPackable>true</IsPackable>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
+
+  <!-- Set package ID for official signed builds. Needed to publish both Windows and Linux signed packages to build asset registry. -->
+  <PropertyGroup Condition="'$(DotNetSignType)' == 'real'">
+    <BuildRid Condition="'$(BuildRid)' == '' and '$(MSBuildRuntimeType)' == 'core'">$([System.Runtime.InteropServices.RuntimeInformation]::RuntimeIdentifier)</BuildRid>
+    <TargetArchitecture Condition="'$(TargetArchitecture)' == ''">$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant)</TargetArchitecture>
+    <TargetOS Condition="'$(TargetOS)' == ''">$(BuildRid.Substring(0, $(BuildRid.LastIndexOf('-'))))</TargetOS>
+    <TargetRid Condition="'$(TargetRid)' == ''">$(TargetOS)-$(TargetArchitecture)</TargetRid>
+    <PackageId>Validation.$(TargetRid)</PackageId>
+  </PropertyGroup>
   
 </Project>


### PR DESCRIPTION
Related to https://github.com/dotnet/arcade/issues/14431

Validates the changes in https://github.com/dotnet/arcade/pull/15104 for Linux (Mac is currently blocked - see https://github.com/dotnet/arcade/issues/14431#issuecomment-2387129090)


[Test pipeline run](https://dev.azure.com/dnceng/internal/_build/results?buildId=2552857&view=results) (internal Microsoft link)