### PR TITLE
Remove `native-tools` from global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -7,10 +7,6 @@
       ]
     }
   },
-  "native-tools": {
-    "cmake": "3.11.1",
-    "cmake-test": "3.11.1"
-  },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.24529.1",
     "Microsoft.DotNet.Helix.Sdk": "10.0.0-beta.24529.1"


### PR DESCRIPTION
- see https://github.com/dotnet/dnceng/issues/4204
- not required to build the repo; all code here is C#
  - section existed only to validate parallel installation of two native tools
- we now want macOS coverage and `cmake` layout is different on that OS