### PR TITLE
Properly containerize CI/PR builds

### DIFF
--- a/azure-pipelines-pr.yml
+++ b/azure-pipelines-pr.yml
@@ -16,7 +16,7 @@ pr:
 resources:
   containers:
   - container: LinuxContainer
-    image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm
+    image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-cross-amd64
 
 stages:
 - stage: build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,7 +45,7 @@ extends:
       os: windows
     containers:
       LinuxContainer:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net9.0-cross-amd64
       
     stages:
     - stage: build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,9 +30,6 @@ schedules:
   always: true
 
 resources:
-  containers:
-  - container: LinuxContainer
-    image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm
   repositories:
   - repository: 1ESPipelineTemplates
     type: git
@@ -46,6 +43,9 @@ extends:
       name: $(PoolProvider)
       image: windows.vs2022.amd64
       os: windows
+    containers:
+      LinuxContainer:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm
       
     stages:
     - stage: build


### PR DESCRIPTION
Internal builds were not being properly containerized with the 1ES templates. This PR also updates the container from cbl-mariner 2.0 to azurelinux 3.0

Proper containerization is needed to test the validity of the MicroBuild signing plugin tasks.

[Test build](https://dev.azure.com/dnceng/internal/_build/results?buildId=2616847&view=results)