### PR TITLE
Removing EOL software

### DIFF
--- a/azure-pipelines-pr.yml
+++ b/azure-pipelines-pr.yml
@@ -16,7 +16,7 @@ pr:
 resources:
   containers:
   - container: LinuxContainer
-    image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm
+    image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-fpm-amd64
 
 stages:
 - stage: build
@@ -59,7 +59,7 @@ stages:
         container: LinuxContainer
         pool:
           name: $(PoolProvider)  # This is a queue-time parameter; Public default is NetCore-Svc-Public; Internal default is NetCore1ESPool-Svc-Internal
-          demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
+          demands: ImageOverride -equals Build.Ubuntu.2204.Amd64.Open
         strategy:
           matrix:
             Build_Debug:
@@ -100,7 +100,7 @@ stages:
             DotNetCliVersion: 8.0.100
             EnableXUnitReporter: true
             WaitForWorkItemCompletion: true
-            HelixTargetQueues: Windows.Amd64.Server2022.Open;(Debian.10.Amd64.Open)Ubuntu.2004.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-10-helix-amd64
+            HelixTargetQueues: Windows.Amd64.Server2022.Open;(Debian.12.Amd64.Open)Azurelinux.3.amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-12-helix-amd64
             HelixSource: pr/dotnet/arcade-validation/$(Build.SourceBranch)
             IsExternal: true
             Creator: arcade-validation

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,7 +32,7 @@ schedules:
 resources:
   containers:
   - container: LinuxContainer
-    image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm
+    image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-fpm-amd64
   repositories:
   - repository: 1ESPipelineTemplates
     type: git
@@ -138,7 +138,7 @@ extends:
                 DotNetCliVersion: 8.0.100
                 EnableXUnitReporter: true
                 WaitForWorkItemCompletion: true
-                HelixTargetQueues: Windows.Amd64.Server2022;(Debian.10.Amd64)Ubuntu.2004.Amd64@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-10-helix-amd64
+                HelixTargetQueues: Windows.Amd64.Server2022;(Debian.12.Amd64)Ubuntu.2204.Amd64@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-12-helix-amd64
                 HelixSource: official/dotnet/arcade-validation/$(Build.SourceBranch)
                 HelixAccessToken: $(HelixApiAccessToken)
             displayName: Validate Helix


### PR DESCRIPTION
Replacing Ubuntu 18.04 with Ubuntu 22.04, Mariner 2 with Azure Linux 3 and Debian 10 with Debian 12