### PR TITLE
updated script for arcade promotion into .net 6

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -214,8 +214,5 @@ extends:
               - checkout: self
                 clean: True
               - pwsh: eng/validation/update-channel.ps1
-                      -maestroEndpoint https://maestro-prod.westus2.cloudapp.azure.com
-                      -barToken $(MaestroAccessToken)
                       -azdoToken $(dn-bot-dnceng-build-rw-code-rw)
-                      -githubToken $(BotAccount-dotnet-bot-repo-PAT)
                 displayName: Promote Arcade to '.NET 6 Eng' channel

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -213,6 +213,11 @@ extends:
             steps:
               - checkout: self
                 clean: True
-              - pwsh: eng/validation/update-channel.ps1
-                      -azdoToken $(dn-bot-dnceng-build-rw-code-rw)
+              - task: AzureCLI@2
                 displayName: Promote Arcade to '.NET 6 Eng' channel
+                inputs:
+                  azureSubscription: "Darc: Maestro Production"
+                  scriptType: ps
+                  scriptLocation: scriptPath
+                  scriptPath: $(Build.SourcesDirectory)/eng/validation/update-channel.ps1
+                  arguments: -azdoToken $(dn-bot-dnceng-build-rw-code-rw)

--- a/eng/validation/update-channel.ps1
+++ b/eng/validation/update-channel.ps1
@@ -25,7 +25,7 @@ try {
         exit 1
     }
 
-    $buildId = $assets[0].'buildId'
+    $buildId = $assets[0].build.id
 
     & $darc add-build-to-channel --id $buildId --channel "$targetChannelName" --azdev-pat $azdoToken --ci --skip-assets-publishing
         

--- a/eng/validation/update-channel.ps1
+++ b/eng/validation/update-channel.ps1
@@ -1,10 +1,6 @@
 Param(
-  [string] $maestroEndpoint,
-  [string] $barToken,
-  [string] $apiVersion = "2018-07-16",
   [string] $targetChannelName = ".NET 6 Eng",
-  [string] $azdoToken,
-  [string] $githubToken
+  [string] $azdoToken
 )
 
 $ci = $true
@@ -12,21 +8,12 @@ $ci = $true
 . $PSScriptRoot\..\common\pipeline-logging-functions.ps1
 $darc = & "$PSScriptRoot\get-darc.ps1"
 
-function Get-Headers([string]$accept, [string]$barToken) {
-    $headers = New-Object 'System.Collections.Generic.Dictionary[[String],[String]]'
-    $headers.Add('Accept',$accept)
-    $headers.Add('Authorization',"Bearer $barToken")
-    return $headers
-}
-
 $arcadeSdkPackageName = 'Microsoft.DotNet.Arcade.Sdk'
 $arcadeSdkVersion = $GlobalJson.'msbuild-sdks'.$arcadeSdkPackageName
-$getAssetsApiEndpoint = "$maestroEndpoint/api/assets?name=$arcadeSdkPackageName&version=$arcadeSdkVersion&api-version=$apiVersion"
-$headers = Get-Headers 'text/plain' $barToken
 
 try {
     # Get the Microsoft.DotNet.Arcade.Sdk with the version $arcadeSdkVersion so we can get the id of the build
-    $assets = Invoke-WebRequest -Uri $getAssetsApiEndpoint -Headers $headers | ConvertFrom-Json
+    $assets = & $darc get-asset --name $arcadeSdkPackageName --version $arcadeSdkVersion --ci --output-format json | ConvertFrom-Json
 
     if (!$assets) {
         Write-Host "Asset '$arcadeSdkPackageName' with version $arcadeSdkVersion was not found"
@@ -40,7 +27,7 @@ try {
 
     $buildId = $assets[0].'buildId'
 
-    & $darc add-build-to-channel --id $buildId --channel "$targetChannelName" --github-pat $githubToken --azdev-pat $azdoToken --password $barToken --skip-assets-publishing
+    & $darc add-build-to-channel --id $buildId --channel "$targetChannelName" --azdev-pat $azdoToken --ci --skip-assets-publishing
         
     if ($LastExitCode -ne 0) {
         Write-Host "Problems using Darc to promote build ${buildId} to channel ${targetChannelName}. Stopping execution..."


### PR DESCRIPTION
Arcade-validation is failing to promote Arcade to the .net 6 eng channel as seen from this discussion: [Microsoft.Guardian.Cli CG alert](https://teams.microsoft.com/l/message/19:afba3d1545dd45d7b79f34c1821f6055@thread.skype/1747694727991?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=4d73664c-9f2f-450d-82a5-c2f02756606d&parentMessageId=1747694727991&teamName=.NET%20Core%20Eng%20Services%20Partners&channelName=First%20Responders&createdTime=1747694727991)

Changes were made to main, 8.0 and 9.0, but 6.0 and 7.0 are still using the old maestro, which causes the promotion step to fail.
This PR addresses the issue to enable 6.0 to use the new maestro